### PR TITLE
Clean Old Omports

### DIFF
--- a/roboconf-agent/src/main/java/net/roboconf/agent/internal/Agent.java
+++ b/roboconf-agent/src/main/java/net/roboconf/agent/internal/Agent.java
@@ -625,6 +625,7 @@ public class Agent implements IMessageProcessor {
 		for( Instance i : instancesToStop ) {
 			// Delete files for undeployed instances
 			deleteInstanceResources( i, plugin.getPluginName());
+			i.getImports().clear(); // To prevent old imports from being resent later on
 			updateAndNotifyNewStatus( i, InstanceStatus.NOT_DEPLOYED );
 		}
 

--- a/roboconf-dm/src/main/java/net/roboconf/dm/management/Manager.java
+++ b/roboconf-dm/src/main/java/net/roboconf/dm/management/Manager.java
@@ -477,6 +477,7 @@ public final class Manager {
 
 				this.logger.fine( "Machine " + rootInstance.getName() + " was successfully deleted." );
 				rootInstance.setStatus( InstanceStatus.NOT_DEPLOYED );
+				rootInstance.getImports().clear(); // DM won't send old imports upon restart...
 			}
 
 		} catch( IaasException e ) {


### PR DESCRIPTION
Removed imports when undeploying, to prevent old imports from being re-sent at next deploy/start.
