### PR TITLE
Add DM monitoring feature

### DIFF
--- a/core/roboconf-dm-monitoring/.gitignore
+++ b/core/roboconf-dm-monitoring/.gitignore
@@ -1,0 +1,19 @@
+*.class
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# Maven related elements or those that can be generated from the POM
+.project
+.classpath
+/.externalToolBuilders
+/target
+/bin
+/maven-eclipse.xml
+/.settings
+
+#idea
+*.iml
+.idea/

--- a/core/roboconf-dm-monitoring/pom.xml
+++ b/core/roboconf-dm-monitoring/pom.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+   Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+
+   The present code is developed in the scope of the joint LINAGORA -
+   Université Joseph Fourier - Floralis research program and is designated
+   as a "Result" pursuant to the terms and conditions of the LINAGORA
+   - Université Joseph Fourier - Floralis research program. Each copyright
+   holder of Results enumerated here above fully & independently holds complete
+   ownership of the complete Intellectual Property rights applicable to the whole
+   of said Results, and may freely exploit it in any manner which does not infringe
+   the moral rights of the other copyright holders.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>net.roboconf</groupId>
+		<artifactId>roboconf-platform-parent</artifactId>
+		<version>0.4-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+
+	<groupId>net.roboconf</groupId>
+	<artifactId>roboconf-dm-monitoring</artifactId>
+	<name>Roboconf :: Deployment Manager :: Monitoring</name>
+	<packaging>bundle</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>net.roboconf</groupId>
+			<artifactId>roboconf-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>net.roboconf</groupId>
+			<artifactId>roboconf-dm</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>org.apache.felix.ipojo.annotations</artifactId>
+			<version>1.12.1</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.jknack</groupId>
+			<artifactId>handlebars</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.easytesting</groupId>
+			<artifactId>fest-assert</artifactId>
+			<version>1.4</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<!-- We use a fresher version.-->
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>net.roboconf</groupId>
+			<artifactId>roboconf-core</artifactId>
+			<type>test-jar</type>
+			<version>0.4-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<configuration>
+					<instructions>
+						<Import-Package>
+							net.roboconf.*;version="${project.version}",
+							org.slf4j;version="[1.6.4,2.0.0)",
+						</Import-Package>
+						<Export-Package>net.roboconf.dm.monitoring;version="${project.version}"</Export-Package>
+						<Private-Package>net.roboconf.dm.monitoring.internal</Private-Package>
+						<Embed-Dependency>
+							commons-io,
+							handlebars,
+							commons-lang3,
+							antlr4-runtime
+						</Embed-Dependency>
+						<Embed-Transitive>true</Embed-Transitive>
+					</instructions>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-ipojo-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>ipojo-bundle</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/core/roboconf-dm-monitoring/pom.xml
+++ b/core/roboconf-dm-monitoring/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>org.apache.felix</groupId>
 			<artifactId>org.apache.felix.ipojo.annotations</artifactId>
-			<version>1.12.1</version>
+			<version>${ipojo.version}</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/MonitoringService.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/MonitoringService.java
@@ -40,31 +40,31 @@ import net.roboconf.core.model.beans.Application;
 public interface MonitoringService {
 
 	/**
-	 * The name of the directory where application monitoring templates are read from, relative to the Roboconf
+	 * The name of the directory where application templates are read from, relative to the Roboconf configuration
+	 * directory.
+	 */
+	String TEMPLATE_DIRECTORY = "templates";
+
+	/**
+	 * The name of the directory where application generated files are written/updated, relative to the Roboconf
 	 * configuration directory.
 	 */
-	String MONITORING_TEMPLATE_DIRECTORY = "monitoring-template";
+	String TARGET_DIRECTORY = "generated";
 
 	/**
-	 * The name of the directory where application monitoring generated files are written/updated, relative to the
-	 * Roboconf configuration directory.
+	 * The extension for template files.
 	 */
-	String MONITORING_TARGET_DIRECTORY = "monitoring-generated";
+	String TEMPLATE_FILE_EXTENSION = ".tpl";
 
 	/**
-	 * The extension of monitoring template files.
-	 */
-	String MONITORING_TEMPLATE_FILE_EXTENSION = ".tpl";
-
-	/**
-	 * Get the target directory, where monitoring reports are generated.
+	 * Gets the target directory, where monitoring reports are generated.
 	 *
 	 * @return the target directory.
 	 */
 	File getTargetDirectory();
 
 	/**
-	 * Add a monitoring template.
+	 * Adds a monitoring template.
 	 *
 	 * @param application the application scope for the template to add, or {@code null} to add a global template.
 	 * @param name        the name of the template to add.
@@ -77,7 +77,7 @@ public interface MonitoringService {
 	boolean addTemplate( Application application, String name, InputStream content ) throws IOException;
 
 	/**
-	 * Get the current list of the monitoring templates, for the given application.
+	 * Gets the current list of the monitoring templates, for the given application.
 	 * <p>
 	 * The returned set <em>does not</em> contain the global template identifiers, as they may collide with the
 	 * application-specific template identifiers. In order to get the global template, call this method with the
@@ -91,7 +91,7 @@ public interface MonitoringService {
 	Set<String> listTemplates( Application application );
 
 	/**
-	 * Remove a monitoring template.
+	 * Removes a monitoring template.
 	 *
 	 * @param application the application scope for the template to remove, or {@code null} to remove a global
 	 *                    template.

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/MonitoringService.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/MonitoringService.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
+import net.roboconf.core.model.beans.Application;
+
+/**
+ * Interface for monitoring template management.
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public interface MonitoringService {
+
+	/**
+	 * The name of the directory where application monitoring templates are read from, relative to the Roboconf
+	 * configuration directory.
+	 */
+	String MONITORING_TEMPLATE_DIRECTORY = "monitoring-template";
+
+	/**
+	 * The name of the directory where application monitoring generated files are written/updated, relative to the
+	 * Roboconf configuration directory.
+	 */
+	String MONITORING_TARGET_DIRECTORY = "monitoring-generated";
+
+	/**
+	 * The extension of monitoring template files.
+	 */
+	String MONITORING_TEMPLATE_FILE_EXTENSION = ".tpl";
+
+	/**
+	 * Get the target directory, where monitoring reports are generated.
+	 *
+	 * @return the target directory.
+	 */
+	File getTargetDirectory();
+
+	/**
+	 * Add a monitoring template.
+	 *
+	 * @param application the application scope for the template to add, or {@code null} to add a global template.
+	 * @param name        the name of the template to add.
+	 * @param content     the content of the template. The stream is not closed by this method, and must be manually
+	 *                    closed afterwards.
+	 * @return {@code true} is the template was successfully added, {@code false} if there is already a template with
+	 * the same name.
+	 * @throws java.io.IOException if the template cannot be added because of an IO error.
+	 */
+	boolean addTemplate( Application application, String name, InputStream content ) throws IOException;
+
+	/**
+	 * Get the current list of the monitoring templates, for the given application.
+	 * <p>
+	 * The returned set <em>does not</em> contain the global template identifiers, as they may collide with the
+	 * application-specific template identifiers. In order to get the global template, call this method with the
+	 * {@code application} parameter set to {@code null}.
+	 * </p>
+	 *
+	 * @param application the application scope for the template to list, or {@code null} to list global templates
+	 *                    only.
+	 * @return the current list of the monitoring templates. The returned list is an immutable snapshot.
+	 */
+	Set<String> listTemplates( Application application );
+
+	/**
+	 * Remove a monitoring template.
+	 *
+	 * @param application the application scope for the template to remove, or {@code null} to remove a global
+	 *                    template.
+	 * @param name        the name of the template to remove.
+	 * @return {@code true} is the template was successfully removed, {@code false} if there was no template with such a
+	 * name.
+	 * @throws java.io.IOException if the template cannot be removed because of an IO error.
+	 */
+	boolean removeTemplate( Application application, String name ) throws IOException;
+
+}

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/AllHelper.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/AllHelper.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring.internal;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Helper needed to select all the instances matching a given criterion.
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public class AllHelper implements Helper<Object> {
+
+	/**
+	 * The name of this helper.
+	 */
+	public static final String NAME = "all";
+
+	/**
+	 * A singleton instance of this helper.
+	 */
+	public static final Helper<Object> INSTANCE = new AllHelper();
+
+	/**
+	 * Select instances according to a selection path.
+	 * For example:
+	 *
+	 * <pre>
+	 * {{#all children path="/VM/Apache" installer="script"}}
+	 *   {{path}}
+	 * {{/all}}
+	 * </pre>
+	 */
+	@Override
+	public CharSequence apply( final Object context, final Options options ) throws IOException {
+		final CharSequence result;
+
+		if (context instanceof ApplicationContextBean) {
+			// Implicit: all instances of the application.
+			result = safeApply( ((ApplicationContextBean) context).instances, options );
+		} else if (context instanceof InstanceContextBean) {
+			// Implicit: all descendants of the instance.
+			result = safeApply( descendantInstances((InstanceContextBean) context), options );
+		} else if (context instanceof Collection<?>) {
+			// Collection of instances. We must ensure type-safety.
+			final Collection<InstanceContextBean> safeContext = new ArrayList<InstanceContextBean>();
+			for (final Object element : (Collection<?>) context) {
+				if (element instanceof InstanceContextBean) {
+					safeContext.add( (InstanceContextBean) element );
+				}
+			}
+			result = safeApply( safeContext, options );
+		} else {
+			result = StringUtils.EMPTY;
+		}
+
+
+		return result;
+	}
+
+	/**
+	 * Return all the descendant instances of the given instance.
+	 *
+	 * @param instance the instance which descendants must be retrieved.
+	 * @return the descendants of the given instance.
+	 */
+	private static Collection<InstanceContextBean> descendantInstances( final InstanceContextBean instance ) {
+		final Collection<InstanceContextBean> result = new ArrayList<InstanceContextBean>();
+		for (final InstanceContextBean child : instance.children) {
+			result.add( child );
+			result.addAll( descendantInstances( child ) );
+		}
+		return result;
+	}
+
+	/**
+	 * Same as above, but with type-safe arguments.
+	 *
+	 * @param instances the instances to which this helper is applied.
+	 * @param options   the options of this helper invocation.
+	 * @return a string result.
+	 * @throws IOException if a template cannot be loaded.
+	 */
+	private String safeApply( final Collection<InstanceContextBean> instances, final Options options ) throws IOException {
+		final String path = options.param( 0, InstanceFilter.JOKER );
+
+		// Parse the filter.
+		final InstanceFilter filter = InstanceFilter.createFilter( path );
+
+		// Apply the filter.
+		final Collection<InstanceContextBean> selectedInstances = filter.apply( instances );
+
+		// Apply the content template of the helper to each selected instance.
+		final StringBuilder buffer = new StringBuilder();
+		final Context parent = options.context;
+		int index = 0;
+		final int last = selectedInstances.size() - 1;
+		for (final InstanceContextBean instance : selectedInstances) {
+			final Context current = Context.newBuilder( parent, instance )
+					.combine( "@index", index )
+					.combine( "@first", index == 0 ? "first" : "" )
+					.combine( "@last", index == last ? "last" : "" )
+					.combine( "@odd", index % 2 == 0 ? "" : "odd" )
+					.combine( "@even", index % 2 == 0 ? "even" : "" )
+					.build();
+			index++;
+			buffer.append( options.fn( current ) );
+		}
+		return buffer.toString();
+	}
+
+}

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/ApplicationContextBean.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/ApplicationContextBean.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring.internal;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Context bean for a Roboconf application.
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public class ApplicationContextBean {
+	String name;
+	String description;
+	Date lastModified;
+	final Set<InstanceContextBean> instances = new LinkedHashSet<InstanceContextBean>();
+	final Set<String> components = new LinkedHashSet<String>();
+	final Map<String, Set<InstanceContextBean>> instancesByType = new LinkedHashMap<String, Set<InstanceContextBean>>();
+
+	public String getName() {
+		return this.name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public Date getLastModified() {
+		return this.lastModified;
+	}
+
+	public Collection<InstanceContextBean> getInstances() {
+		return this.instances;
+	}
+
+	public Collection<String> getComponents() {
+		return this.components;
+	}
+
+	public Map<String, Set<InstanceContextBean>> getInstancesByType() {
+		return this.instancesByType;
+	}
+
+	@Override
+	public String toString() {
+		return this.name;
+	}
+}

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/ImportContextBean.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/ImportContextBean.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring.internal;
+
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Context bean for an imported variable.
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public class ImportContextBean {
+	String component;
+	InstanceContextBean instance;
+	final Set<VariableContextBean> variables = new LinkedHashSet<VariableContextBean>();
+
+	public String getComponent() {
+		return this.component;
+	}
+
+	public InstanceContextBean getInstance() {
+		return this.instance;
+	}
+
+	public Set<VariableContextBean> getVariables() {
+		return this.variables;
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder( "import from " + this.instance.path + ':' );
+		for (final Iterator<VariableContextBean> i = this.variables.iterator(); i.hasNext(); ) {
+			sb.append( i.next() );
+			if (i.hasNext()) {
+				sb.append( ", " );
+			}
+		}
+		return sb.toString();
+	}
+}

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/ImportContextBean.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/ImportContextBean.java
@@ -53,11 +53,11 @@ public class ImportContextBean {
 
 	@Override
 	public String toString() {
-		final StringBuilder sb = new StringBuilder( "import from " + this.instance.path + ':' );
+		final StringBuilder sb = new StringBuilder("import from " + this.instance.path + ':');
 		for (final Iterator<VariableContextBean> i = this.variables.iterator(); i.hasNext(); ) {
-			sb.append( i.next() );
+			sb.append(i.next());
 			if (i.hasNext()) {
-				sb.append( ", " );
+				sb.append(", ");
 			}
 		}
 		return sb.toString();

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/InstanceContextBean.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/InstanceContextBean.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring.internal;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import net.roboconf.core.model.beans.Instance;
+
+/**
+ * Context bean for a Roboconf instance.
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public class InstanceContextBean {
+	String name;
+	String path;
+	Instance.InstanceStatus status;
+	boolean statusIsStable;
+	String component;
+	final Set<String> types = new LinkedHashSet<String>();
+	InstanceContextBean parent;
+	final Set<InstanceContextBean> children = new LinkedHashSet<InstanceContextBean>();
+	String ip;
+	String installer;
+	final Set<VariableContextBean> exports = new LinkedHashSet<VariableContextBean>();
+	final Set<ImportContextBean> imports = new LinkedHashSet<ImportContextBean>();
+	final Set<VariableContextBean> data = new LinkedHashSet<VariableContextBean>();
+
+	public String getName() {
+		return this.name;
+	}
+
+	public String getPath() {
+		return this.path;
+	}
+
+	public Instance.InstanceStatus getStatus() {
+		return this.status;
+	}
+
+	public boolean getStatusIsStable() {
+		return this.statusIsStable;
+	}
+
+	public String getComponent() {
+		return this.component;
+	}
+
+	public Set<String> getTypes() {
+		return this.types;
+	}
+
+	public InstanceContextBean getParent() {
+		return this.parent;
+	}
+
+	public Set<InstanceContextBean> getChildren() {
+		return this.children;
+	}
+
+	public String getIp() {
+		return this.ip;
+	}
+
+	public Set<VariableContextBean> getExports() {
+		return this.exports;
+	}
+
+	public String getInstaller() {
+		return this.installer;
+	}
+
+	public Set<ImportContextBean> getImports() {
+		return this.imports;
+	}
+
+	public Set<VariableContextBean> getData() {
+		return this.data;
+	}
+
+	@Override
+	public String toString() {
+		return this.path;
+	}
+}

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/InstanceFilter.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/InstanceFilter.java
@@ -32,7 +32,7 @@ import java.util.LinkedList;
 
 /**
  * An instance filter based on a component path and/or an installer name.
- * 
+ *
  * <p>
  * This filter is used in the {@linkplain AllHelper all} Handlebars template helper.
  * </p>
@@ -81,10 +81,10 @@ public final class InstanceFilter {
 	 */
 	public static InstanceFilter createFilter( final String path ) {
 		// Split the path.
-		final String[] elements = path.split( PATH_SEPARATOR, -1 );
+		final String[] elements = path.split(PATH_SEPARATOR, -1);
 		final int last = elements.length - 1;
 		if (last == -1) {
-			throw new IllegalArgumentException( "Empty component path" );
+			throw new IllegalArgumentException("Empty component path");
 		}
 
 		// Iterate in reverse order, as the instances we want are those on the right side of the path.
@@ -94,16 +94,16 @@ public final class InstanceFilter {
 			final String element = elements[i];
 
 			// Sanity checks
-			if (element.isEmpty() || element.contains( JOKER ) && element.length() != JOKER.length()) {
-				throw new IllegalArgumentException( "Empty component path: " + path );
+			if (element.isEmpty() || element.contains(JOKER) && element.length() != JOKER.length()) {
+				throw new IllegalArgumentException("Empty component path: " + path);
 			}
 
 			// Node for the current element.
 			final AndNode currentNode = new AndNode();
 
 			// Type name filter
-			if (!JOKER.equals( element )) {
-				currentNode.delegates.add( new TypeNode( element ) );
+			if (!JOKER.equals(element)) {
+				currentNode.delegates.add(new TypeNode(element));
 			}
 
 			// Special handling if the path begins with a leading '/'.
@@ -111,7 +111,7 @@ public final class InstanceFilter {
 			// In this case the first element is empty "", despite the component path remains valid.
 			// The following element (at index 1) must match root instances only.
 			if (i == 1 && elements[0].isEmpty()) {
-				currentNode.delegates.add( new RootInstanceNode() );
+				currentNode.delegates.add(new RootInstanceNode());
 				// The next element is an empty string.
 				// If we don't shortcut it, it will make the next iteration fail.
 				// Skip it by forcing the index to its ending bound.
@@ -123,14 +123,14 @@ public final class InstanceFilter {
 				rootNode = currentNode;
 			} else {
 				// Chain the current node with its parent node.
-				parentNode.delegates.add( new ParentInstanceNode( currentNode ) );
+				parentNode.delegates.add(new ParentInstanceNode(currentNode));
 			}
 
 			// Shift and reiterate.
 			parentNode = currentNode;
 		}
 
-		return new InstanceFilter( path, rootNode );
+		return new InstanceFilter(path, rootNode);
 	}
 
 	/**
@@ -142,8 +142,8 @@ public final class InstanceFilter {
 	public Collection<InstanceContextBean> apply( Collection<InstanceContextBean> instances ) {
 		final ArrayList<InstanceContextBean> result = new ArrayList<InstanceContextBean>();
 		for (InstanceContextBean instance : instances) {
-			if (rootNode.isMatching( instance )) {
-				result.add( instance );
+			if (rootNode.isMatching(instance)) {
+				result.add(instance);
 			}
 		}
 		result.trimToSize();
@@ -152,7 +152,7 @@ public final class InstanceFilter {
 
 	/**
 	 * Get the path string of this filter.
-	 * 
+	 *
 	 * @return the path string of this filter.
 	 */
 	public String getPath() {
@@ -194,7 +194,7 @@ public final class InstanceFilter {
 		boolean isMatching( final InstanceContextBean instance ) {
 			boolean result = true;
 			for (Node n : this.delegates) {
-				if (!n.isMatching( instance )) {
+				if (!n.isMatching(instance)) {
 					result = false;
 					break;
 				}
@@ -223,7 +223,7 @@ public final class InstanceFilter {
 
 		@Override
 		boolean isMatching( final InstanceContextBean instance ) {
-			return instance.types.contains( typeName );
+			return instance.types.contains(typeName);
 		}
 	}
 
@@ -248,7 +248,7 @@ public final class InstanceFilter {
 
 		@Override
 		boolean isMatching( final InstanceContextBean instance ) {
-			return instance.parent != null && parentInstanceNode.isMatching( instance.parent );
+			return instance.parent != null && parentInstanceNode.isMatching(instance.parent);
 		}
 
 	}

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/InstanceFilter.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/InstanceFilter.java
@@ -1,0 +1,266 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring.internal;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+
+/**
+ * An instance filter based on a component path and/or an installer name.
+ * 
+ * <p>
+ * This filter is used in the {@linkplain AllHelper all} Handlebars template helper.
+ * </p>
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public final class InstanceFilter {
+
+	/**
+	 * The joker character, matching any component.
+	 */
+	public static final String JOKER = "*";
+
+	/**
+	 * The separator for instance filters.
+	 */
+	public static final String PATH_SEPARATOR = "/";
+
+	/**
+	 * The path of this filter, exactly as requested at creation time.
+	 */
+	private final String path;
+
+	/**
+	 * The root node of this filter.
+	 */
+	private final Node rootNode;
+
+	/**
+	 * Private constructor.
+	 *
+	 * @param path     component path.
+	 * @param rootNode the root node.
+	 */
+	private InstanceFilter( String path, Node rootNode ) {
+		this.path = path;
+		this.rootNode = rootNode;
+	}
+
+	/**
+	 * Factory for {@code Filter}s.
+	 *
+	 * @param path component path for the filter to be created.
+	 * @return the created filter.
+	 * @throws IllegalArgumentException if {@code path} is an illegal component path.
+	 */
+	public static InstanceFilter createFilter( final String path ) {
+		// Split the path.
+		final String[] elements = path.split( PATH_SEPARATOR, -1 );
+		final int last = elements.length - 1;
+		if (last == -1) {
+			throw new IllegalArgumentException( "Empty component path" );
+		}
+
+		// Iterate in reverse order, as the instances we want are those on the right side of the path.
+		AndNode rootNode = null;
+		AndNode parentNode = null;
+		for (int i = last; i >= 0; i--) {
+			final String element = elements[i];
+
+			// Sanity checks
+			if (element.isEmpty() || element.contains( JOKER ) && element.length() != JOKER.length()) {
+				throw new IllegalArgumentException( "Empty component path: " + path );
+			}
+
+			// Node for the current element.
+			final AndNode currentNode = new AndNode();
+
+			// Type name filter
+			if (!JOKER.equals( element )) {
+				currentNode.delegates.add( new TypeNode( element ) );
+			}
+
+			// Special handling if the path begins with a leading '/'.
+			// It means that the instance must be a root instance.
+			// In this case the first element is empty "", despite the component path remains valid.
+			// The following element (at index 1) must match root instances only.
+			if (i == 1 && elements[0].isEmpty()) {
+				currentNode.delegates.add( new RootInstanceNode() );
+				// The next element is an empty string.
+				// If we don't shortcut it, it will make the next iteration fail.
+				// Skip it by forcing the index to its ending bound.
+				i = 0;
+			}
+
+			if (rootNode == null) {
+				// The current node  is the root node. We have no parent node yet.
+				rootNode = currentNode;
+			} else {
+				// Chain the current node with its parent node.
+				parentNode.delegates.add( new ParentInstanceNode( currentNode ) );
+			}
+
+			// Shift and reiterate.
+			parentNode = currentNode;
+		}
+
+		return new InstanceFilter( path, rootNode );
+	}
+
+	/**
+	 * Apply this filter to the given instances.
+	 *
+	 * @param instances the collection of instances to which this filter has to be applied.
+	 * @return the instances of the provided collection that matches this filter.
+	 */
+	public Collection<InstanceContextBean> apply( Collection<InstanceContextBean> instances ) {
+		final ArrayList<InstanceContextBean> result = new ArrayList<InstanceContextBean>();
+		for (InstanceContextBean instance : instances) {
+			if (rootNode.isMatching( instance )) {
+				result.add( instance );
+			}
+		}
+		result.trimToSize();
+		return Collections.unmodifiableCollection(result);
+	}
+
+	/**
+	 * Get the path string of this filter.
+	 * 
+	 * @return the path string of this filter.
+	 */
+	public String getPath() {
+		return this.path;
+	}
+
+	@Override
+	public String toString() {
+		return super.toString() + "[path=" + this.path + ']';
+	}
+
+	/**
+	 * Basic element of an instance filter.
+	 */
+	private static abstract class Node {
+		/**
+		 * Test if an instance matches this instance filter node.
+		 *
+		 * @param instance the instance to test.
+		 * @return {@code true} if and only if the given instance matches this instance filter node.
+		 */
+		abstract boolean isMatching( InstanceContextBean instance );
+	}
+
+	/**
+	 * And-combination of several nodes.
+	 * <p>
+	 * As a corner-case property, an {@code AndNode} without delegates matches any instance. It is used to handle the
+	 * special {@value #JOKER} path element.
+	 * </p>
+	 */
+	private static class AndNode extends Node {
+		/**
+		 * The delegate nodes.
+		 */
+		final LinkedList<Node> delegates = new LinkedList<Node>();
+
+		@Override
+		boolean isMatching( final InstanceContextBean instance ) {
+			boolean result = true;
+			for (Node n : this.delegates) {
+				if (!n.isMatching( instance )) {
+					result = false;
+					break;
+				}
+			}
+			return result;
+		}
+	}
+
+	/**
+	 * A node that only matches instances of a given type.
+	 */
+	private static class TypeNode extends Node {
+		/**
+		 * The name of the matching component.
+		 */
+		final String typeName;
+
+		/**
+		 * Create a {@code TypeNode} that matches instances of the type with the given name.
+		 *
+		 * @param typeName the name of the type to match.
+		 */
+		TypeNode( final String typeName ) {
+			this.typeName = typeName;
+		}
+
+		@Override
+		boolean isMatching( final InstanceContextBean instance ) {
+			return instance.types.contains( typeName );
+		}
+	}
+
+	/**
+	 * A node that matches instances based on their parent.
+	 */
+	private static class ParentInstanceNode extends Node {
+		/**
+		 * The node that test the parent instances.
+		 */
+		final Node parentInstanceNode;
+
+		/**
+		 * Create a {@code ParentInstanceNode} that matches instances whose parent matches the given parent instance
+		 * node.
+		 *
+		 * @param parentInstanceNode the node that test the parent instances.
+		 */
+		ParentInstanceNode( final Node parentInstanceNode ) {
+			this.parentInstanceNode = parentInstanceNode;
+		}
+
+		@Override
+		boolean isMatching( final InstanceContextBean instance ) {
+			return instance.parent != null && parentInstanceNode.isMatching( instance.parent );
+		}
+
+	}
+
+	/**
+	 * A node that only matches root instances.
+	 */
+	private static class RootInstanceNode extends Node {
+		@Override
+		boolean isMatching( final InstanceContextBean instance ) {
+			return instance.parent == null;
+		}
+	}
+
+}

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/MonitoredApplication.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/MonitoredApplication.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring.internal;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+
+import com.github.jknack.handlebars.Context;
+import net.roboconf.core.model.beans.AbstractType;
+import net.roboconf.core.model.beans.Application;
+import net.roboconf.core.model.beans.Component;
+import net.roboconf.core.model.beans.Facet;
+import net.roboconf.core.model.beans.Import;
+import net.roboconf.core.model.beans.Instance;
+import net.roboconf.core.model.helpers.ComponentHelpers;
+import net.roboconf.core.model.helpers.InstanceHelpers;
+
+import static net.roboconf.core.model.helpers.InstanceHelpers.computeInstancePath;
+
+/**
+ * An application being monitored.
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public class MonitoredApplication {
+
+	/**
+	 * The application's model.
+	 */
+	private final Application model;
+
+	/**
+	 * Create an application entry.
+	 *
+	 * @param model the application's model.
+	 */
+	public MonitoredApplication( final Application model ) {
+		this.model = model;
+	}
+
+	/**
+	 * Get the Roboconf model of this monitored application.
+	 *
+	 * @return the model of this application.
+	 */
+	public Application getModel() {
+		return this.model;
+	}
+
+	/**
+	 * Compute the current monitoring context of this application.
+	 *
+	 * @return the current monitoring context of the application.
+	 */
+	public Context getCurrentContext() {
+		return Context.newBuilder( applicationContext( this.model ) ).build();
+	}
+
+	/**
+	 * Compute the monitoring context of an application.
+	 *
+	 * @return the application's monitoring context.
+	 */
+	public static ApplicationContextBean applicationContext( final Application app ) {
+		final ApplicationContextBean context = new ApplicationContextBean();
+
+		// Model timestamp.
+		context.lastModified = new Date();
+
+		// General application properties.
+		context.name = app.getName();
+		context.description = app.getDescription();
+
+		// Components of the application.
+		for (final Component component : ComponentHelpers.findAllComponents( app )) {
+			context.components.add( component.getName() );
+		}
+
+		// Get all the instances, indexed by path, and compute their initial context.
+		final Map<String, InstanceContextBean> instancesByPath = new LinkedHashMap<String, InstanceContextBean>();
+		final Collection<Instance> allInstances = InstanceHelpers.getAllInstances( app );
+		for (final Instance instance : allInstances) {
+			final InstanceContextBean instanceContext = new InstanceContextBean();
+			final String path = computeInstancePath( instance );
+
+			// General instance properties.
+			instanceContext.path = path;
+			instanceContext.name = instance.getName();
+			instanceContext.status = instance.getStatus();
+			instanceContext.statusIsStable = instance.getStatus().isStable();
+			instanceContext.component = instance.getComponent().getName();
+			instanceContext.types.addAll( findExtendedTypes( instance.getComponent() ) );
+			instanceContext.ip = instance.data.get( Instance.IP_ADDRESS );
+			instanceContext.installer = ComponentHelpers.findComponentInstaller( instance.getComponent() );
+
+			// Instance exports.
+			for (final Map.Entry<String, String> exportEntry : InstanceHelpers.findAllExportedVariables( instance ).entrySet()) {
+				final VariableContextBean export = new VariableContextBean();
+				export.name = exportEntry.getKey();
+				export.value = exportEntry.getValue();
+				instanceContext.exports.add( export );
+			}
+
+			// Instance data.
+			for (final Map.Entry<String, String> dataEntry : instance.data.entrySet()) {
+				final VariableContextBean data = new VariableContextBean();
+				data.name = dataEntry.getKey();
+				data.value = dataEntry.getValue();
+				instanceContext.data.add( data );
+			}
+
+			// Finally add the context to the maps.
+			instancesByPath.put( path, instanceContext );
+			context.instances.add( instanceContext );
+			for (final String typeName : instanceContext.types) {
+				Set<InstanceContextBean> instancesOfType = context.instancesByType.get( typeName );
+				if (instancesOfType == null) {
+					instancesOfType = new LinkedHashSet<InstanceContextBean>();
+					context.instancesByType.put( typeName, instancesOfType );
+				}
+				instancesOfType.add( instanceContext );
+			}
+		}
+
+		// Once the contexts of all the instances have been created, we can add their relationships, which are:
+		// - the parent instance, or null for a root instance.
+		// - the children instances
+		// - the instances from which variables are imported.
+		for (final Instance instance : allInstances) {
+			final InstanceContextBean instanceContext = instancesByPath.get( computeInstancePath( instance ) );
+
+			final Instance parent = instance.getParent();
+			if (parent != null) {
+				instanceContext.parent = instancesByPath.get( computeInstancePath( parent ) );
+			}
+
+			final Collection<Instance> children = instance.getChildren();
+			if (!children.isEmpty()) {
+				for (final Instance child : children) {
+					instanceContext.children.add( instancesByPath.get( computeInstancePath( child ) ) );
+				}
+			}
+
+			for (final Map.Entry<String, Collection<Import>> importedByType : instance.getImports().entrySet()) {
+				for (final Import importedVariable : importedByType.getValue()) {
+					final ImportContextBean importContext = new ImportContextBean();
+					importContext.component = importedVariable.getComponentName();
+					importContext.instance = instancesByPath.get( importedVariable.getInstancePath() );
+					for (Map.Entry<String, String> entry : importedVariable.getExportedVars().entrySet()) {
+						final VariableContextBean variable = new VariableContextBean();
+						variable.name = entry.getKey();
+						variable.value = entry.getValue();
+						importContext.variables.add( variable );
+					}
+					instanceContext.imports.add( importContext );
+				}
+			}
+		}
+
+		return context;
+	}
+
+	/**
+	 * Find all the components and the facets extended by the given component.
+	 * <p>
+	 * The component itself is included in the returned set.
+	 * </p>
+	 *
+	 * @param baseComponent the component whose ancestors must be returned.
+	 * @return the names of all the ancestor components and facets of the given component.
+	 */
+	private static Set<String> findExtendedTypes( final Component baseComponent ) {
+		final LinkedList<AbstractType> types = new LinkedList<AbstractType>();
+		types.add( baseComponent );
+		final Set<String> typeNames = new LinkedHashSet<String>();
+
+		while (!types.isEmpty()) {
+			final AbstractType type = types.removeFirst();
+			// Add the type name to the result set.
+			typeNames.add( type.getName() );
+
+			// Now add all the extended types to the queue.
+			if (type instanceof Component) {
+				// Add the extended components + its facets.
+				final Component component = (Component) type;
+				final Component extended = component.getExtendedComponent();
+				if (extended != null) {
+					types.addLast( extended );
+				}
+				types.addAll( component.getFacets() );
+			} else if (type instanceof Facet) {
+				// Add the extended facets.
+				final Facet facet = (Facet) type;
+				types.addAll( facet.getExtendedFacets() );
+			}
+		}
+		return typeNames;
+	}
+
+}

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/MonitoredApplication.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/MonitoredApplication.java
@@ -37,7 +37,6 @@ import com.github.jknack.handlebars.Context;
 import net.roboconf.core.model.beans.AbstractType;
 import net.roboconf.core.model.beans.Application;
 import net.roboconf.core.model.beans.Component;
-import net.roboconf.core.model.beans.Facet;
 import net.roboconf.core.model.beans.Import;
 import net.roboconf.core.model.beans.Instance;
 import net.roboconf.core.model.helpers.ComponentHelpers;
@@ -81,7 +80,7 @@ public class MonitoredApplication {
 	 * @return the current monitoring context of the application.
 	 */
 	public Context getCurrentContext() {
-		return Context.newBuilder( applicationContext( this.model ) ).build();
+		return Context.newBuilder(applicationContext(this.model)).build();
 	}
 
 	/**
@@ -100,16 +99,16 @@ public class MonitoredApplication {
 		context.description = app.getDescription();
 
 		// Components of the application.
-		for (final Component component : ComponentHelpers.findAllComponents( app )) {
-			context.components.add( component.getName() );
+		for (final Component component : ComponentHelpers.findAllComponents(app)) {
+			context.components.add(component.getName());
 		}
 
 		// Get all the instances, indexed by path, and compute their initial context.
 		final Map<String, InstanceContextBean> instancesByPath = new LinkedHashMap<String, InstanceContextBean>();
-		final Collection<Instance> allInstances = InstanceHelpers.getAllInstances( app );
+		final Collection<Instance> allInstances = InstanceHelpers.getAllInstances(app);
 		for (final Instance instance : allInstances) {
 			final InstanceContextBean instanceContext = new InstanceContextBean();
-			final String path = computeInstancePath( instance );
+			final String path = computeInstancePath(instance);
 
 			// General instance properties.
 			instanceContext.path = path;
@@ -117,16 +116,16 @@ public class MonitoredApplication {
 			instanceContext.status = instance.getStatus();
 			instanceContext.statusIsStable = instance.getStatus().isStable();
 			instanceContext.component = instance.getComponent().getName();
-			instanceContext.types.addAll( findExtendedTypes( instance.getComponent() ) );
-			instanceContext.ip = instance.data.get( Instance.IP_ADDRESS );
-			instanceContext.installer = ComponentHelpers.findComponentInstaller( instance.getComponent() );
+			instanceContext.types.addAll(findExtendedTypes(instance.getComponent()));
+			instanceContext.ip = instance.data.get(Instance.IP_ADDRESS);
+			instanceContext.installer = ComponentHelpers.findComponentInstaller(instance.getComponent());
 
 			// Instance exports.
-			for (final Map.Entry<String, String> exportEntry : InstanceHelpers.findAllExportedVariables( instance ).entrySet()) {
+			for (final Map.Entry<String, String> exportEntry : InstanceHelpers.findAllExportedVariables(instance).entrySet()) {
 				final VariableContextBean export = new VariableContextBean();
 				export.name = exportEntry.getKey();
 				export.value = exportEntry.getValue();
-				instanceContext.exports.add( export );
+				instanceContext.exports.add(export);
 			}
 
 			// Instance data.
@@ -134,19 +133,19 @@ public class MonitoredApplication {
 				final VariableContextBean data = new VariableContextBean();
 				data.name = dataEntry.getKey();
 				data.value = dataEntry.getValue();
-				instanceContext.data.add( data );
+				instanceContext.data.add(data);
 			}
 
 			// Finally add the context to the maps.
-			instancesByPath.put( path, instanceContext );
-			context.instances.add( instanceContext );
+			instancesByPath.put(path, instanceContext);
+			context.instances.add(instanceContext);
 			for (final String typeName : instanceContext.types) {
-				Set<InstanceContextBean> instancesOfType = context.instancesByType.get( typeName );
+				Set<InstanceContextBean> instancesOfType = context.instancesByType.get(typeName);
 				if (instancesOfType == null) {
 					instancesOfType = new LinkedHashSet<InstanceContextBean>();
-					context.instancesByType.put( typeName, instancesOfType );
+					context.instancesByType.put(typeName, instancesOfType);
 				}
-				instancesOfType.add( instanceContext );
+				instancesOfType.add(instanceContext);
 			}
 		}
 
@@ -155,17 +154,17 @@ public class MonitoredApplication {
 		// - the children instances
 		// - the instances from which variables are imported.
 		for (final Instance instance : allInstances) {
-			final InstanceContextBean instanceContext = instancesByPath.get( computeInstancePath( instance ) );
+			final InstanceContextBean instanceContext = instancesByPath.get(computeInstancePath(instance));
 
 			final Instance parent = instance.getParent();
 			if (parent != null) {
-				instanceContext.parent = instancesByPath.get( computeInstancePath( parent ) );
+				instanceContext.parent = instancesByPath.get(computeInstancePath(parent));
 			}
 
 			final Collection<Instance> children = instance.getChildren();
 			if (!children.isEmpty()) {
 				for (final Instance child : children) {
-					instanceContext.children.add( instancesByPath.get( computeInstancePath( child ) ) );
+					instanceContext.children.add(instancesByPath.get(computeInstancePath(child)));
 				}
 			}
 
@@ -173,14 +172,14 @@ public class MonitoredApplication {
 				for (final Import importedVariable : importedByType.getValue()) {
 					final ImportContextBean importContext = new ImportContextBean();
 					importContext.component = importedVariable.getComponentName();
-					importContext.instance = instancesByPath.get( importedVariable.getInstancePath() );
+					importContext.instance = instancesByPath.get(importedVariable.getInstancePath());
 					for (Map.Entry<String, String> entry : importedVariable.getExportedVars().entrySet()) {
 						final VariableContextBean variable = new VariableContextBean();
 						variable.name = entry.getKey();
 						variable.value = entry.getValue();
-						importContext.variables.add( variable );
+						importContext.variables.add(variable);
 					}
-					instanceContext.imports.add( importContext );
+					instanceContext.imports.add(importContext);
 				}
 			}
 		}
@@ -199,28 +198,11 @@ public class MonitoredApplication {
 	 */
 	private static Set<String> findExtendedTypes( final Component baseComponent ) {
 		final LinkedList<AbstractType> types = new LinkedList<AbstractType>();
-		types.add( baseComponent );
+		types.addAll(ComponentHelpers.findAllExtendedComponents(baseComponent));
+		types.addAll(ComponentHelpers.findAllFacets(baseComponent));
 		final Set<String> typeNames = new LinkedHashSet<String>();
-
-		while (!types.isEmpty()) {
-			final AbstractType type = types.removeFirst();
-			// Add the type name to the result set.
-			typeNames.add( type.getName() );
-
-			// Now add all the extended types to the queue.
-			if (type instanceof Component) {
-				// Add the extended components + its facets.
-				final Component component = (Component) type;
-				final Component extended = component.getExtendedComponent();
-				if (extended != null) {
-					types.addLast( extended );
-				}
-				types.addAll( component.getFacets() );
-			} else if (type instanceof Facet) {
-				// Add the extended facets.
-				final Facet facet = (Facet) type;
-				types.addAll( facet.getExtendedFacets() );
-			}
+		for (final AbstractType type : types) {
+			typeNames.add(type.getName());
 		}
 		return typeNames;
 	}

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/MonitoringManager.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/MonitoringManager.java
@@ -1,0 +1,592 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring.internal;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.logging.Logger;
+
+import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.HandlebarsException;
+import net.roboconf.core.model.beans.Application;
+import net.roboconf.core.utils.Utils;
+import net.roboconf.dm.management.MonitoringManagerService;
+import net.roboconf.dm.monitoring.MonitoringService;
+import org.apache.commons.io.filefilter.CanReadFileFilter;
+import org.apache.commons.io.filefilter.FileFilterUtils;
+import org.apache.felix.ipojo.annotations.Component;
+import org.apache.felix.ipojo.annotations.Instantiate;
+import org.apache.felix.ipojo.annotations.Invalidate;
+import org.apache.felix.ipojo.annotations.Property;
+import org.apache.felix.ipojo.annotations.Provides;
+import org.apache.felix.ipojo.annotations.Validate;
+
+
+/**
+ * Component dedicated to the generation of monitoring reports for Roboconf applications.
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+@Component(name = "roboconf-monitoring-manager", managedservice = "net.roboconf.dm.monitoring.configuration",
+		publicFactory = false)
+@Provides(specifications = {MonitoringManagerService.class, MonitoringService.class})
+@Instantiate(name = "Roboconf Monitoring Manager")
+public class MonitoringManager implements MonitoringManagerService, MonitoringService {
+
+	/**
+	 * The big bad global lock.
+	 */
+	private final ReadWriteLock lock = new ReentrantReadWriteLock( true );
+
+	/**
+	 * The Roboconf configuration directory.
+	 *
+	 * @GuardedBy this.lock
+	 * @see #startMonitoring(File)
+	 */
+	private File configDir;
+
+	/**
+	 * The monitoring template directory: {@code ${configDir}}/{@value #MONITORING_TEMPLATE_DIRECTORY}.
+	 *
+	 * @GuardedBy this.lock
+	 * @see #resetTemplateWatcher()
+	 */
+	private File templateDir;
+
+	/**
+	 * The monitoring reports target directory: {@code ${configDir}}/{@value #MONITORING_TARGET_DIRECTORY}.
+	 *
+	 * @GuardedBy this.lock
+	 * @see #resetTemplateWatcher()
+	 */
+	private File targetDir;
+
+	/**
+	 * The poll interval for the template watcher, or any negative value to disable.
+	 *
+	 * @GuardedBy this.lock
+	 * @see #setPollInterval(long)
+	 */
+	private long pollInterval;
+
+	/**
+	 * The monitored applications, indexed by name.
+	 *
+	 * @GuardedBy this.lock
+	 * @see #addApplication(Application)
+	 * @see #removeApplication(Application)
+	 * @see #stopMonitoring()
+	 */
+	private final Map<String, MonitoredApplication> applications = new HashMap<String, MonitoredApplication>();
+
+	/**
+	 * The template watcher.
+	 *
+	 * @GuardedBy this.lock
+	 */
+	private TemplateWatcher templateWatcher;
+
+	/**
+	 * The logger.
+	 */
+	private final Logger logger = Logger.getLogger( this.getClass().getName() );
+
+	/**
+	 * Set the poll interval for the template watcher.
+	 *
+	 * @param pollInterval the poll interval, in milliseconds, for the template watcher.
+	 */
+	@Property(name = "pollInterval", value = "1000")
+	public void setPollInterval( final long pollInterval ) {
+		this.lock.writeLock().lock();
+		try {
+			this.pollInterval = pollInterval;
+			this.logger.config( "Template watcher poll interval set to " + pollInterval );
+
+			// The template watcher needs to be updated.
+			resetTemplateWatcher();
+		} finally {
+			this.lock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Start this iPOJO component instance.
+	 */
+	@Validate
+	public void start() {
+		this.lock.writeLock().lock();
+		try {
+			this.logger.fine( "Component instance is starting..." );
+
+			// Just trigger a reset of the template watcher, it should start it, if it is well-configured.
+			resetTemplateWatcher();
+
+			this.logger.fine( "Component instance is started!" );
+		} finally {
+			this.lock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Stop this iPOJO component instance.
+	 */
+	@Invalidate
+	public void stop() {
+		this.lock.writeLock().lock();
+		try {
+			this.logger.fine( "Component instance is stopping..." );
+
+			// Stop the template watcher, only if it was running.
+			if (this.templateWatcher != null) {
+				this.templateWatcher.stop();
+				this.templateWatcher = null;
+			}
+
+			this.logger.fine( "Component instance is stopped!" );
+		} finally {
+			this.lock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Update the template watcher after a change in the monitoring manager configuration.
+	 *
+	 * @GuardedBy this.lock.writeLock()
+	 */
+	private void resetTemplateWatcher() {
+		// The template & poll interval may have changed. The template watcher must be updated because it is tracking
+		// the templates at a wrong locations now. As hot-updates are *not* possible, and because the template watcher
+		// may need to be stopped completely, we first shut it down, and start it again later, if really needed.
+		if (this.templateWatcher != null) {
+			this.templateWatcher.stop();
+			this.templateWatcher = null;
+		}
+
+		// Update the template & target directories, based on the provided configuration directory.
+		if (this.configDir != null) {
+			this.logger.config( "Reconfiguring template watcher..." );
+
+			this.templateDir = new File( configDir, "monitoring-template" );
+			try {
+				Utils.createDirectory( this.templateDir );
+			} catch (final IOException e) {
+				this.logger.severe( "Cannot access to template directory: " + this.templateDir );
+				Utils.logException( this.logger, e );
+			}
+
+			this.targetDir = new File( configDir, "monitoring-generated" );
+			try {
+				Utils.createDirectory( this.targetDir );
+			} catch (final IOException e) {
+				this.logger.severe( "Cannot access to target directory: " + this.targetDir );
+				Utils.logException( this.logger, e );
+			}
+
+			// Start the template watcher again.
+			try {
+				this.templateWatcher = new TemplateWatcher( this, templateDir, this.pollInterval );
+				this.templateWatcher.start();
+				// The initial provisioning of the template watcher will trigger a full generation of the all the
+				// monitoring reports, for each monitored application. So the new target directory will be repopulated
+				// promptly.
+			} catch (final IOException e) {
+				this.logger.warning( "Cannot create template watcher" );
+				Utils.logException( this.logger, e );
+			}
+		} else {
+			this.logger.config( "Monitoring manager is disabled: no configuration directory set!" );
+			this.templateDir = null;
+			this.targetDir = null;
+			// We do *not* restart the template watcher here, as we wait for the configuration directory to be set.
+		}
+	}
+
+	//
+	// MonitoringManagerService methods
+	//
+
+	@Override
+	public void startMonitoring( final File configDir ) {
+		Objects.requireNonNull( configDir, "configDir is null" );
+		this.lock.writeLock().lock();
+		try {
+			if (this.configDir == null) {
+				this.logger.fine( "Monitoring is starting..." );
+				this.configDir = configDir;
+				this.logger.config( "Configuration directory set to " + this.configDir );
+
+				// The MonitoringManagerService method declaration clearly specifies that all the registered
+				// applications are cleared. This is required since the DM, when reconfigured, stores, removes, and
+				// restore all the applications. When restored, the DM loadApplication() method calls the
+				// addApplication() of this class.
+				this.logger.fine( "Monitored applications have been removed: " + this.applications.keySet() );
+				this.applications.clear();
+
+				// The template watcher is going to be started.
+				resetTemplateWatcher();
+				this.logger.fine( "Monitoring is started!" );
+			}
+		} finally {
+			this.lock.writeLock().unlock();
+		}
+	}
+
+	@Override
+	public void stopMonitoring() {
+		this.lock.writeLock().lock();
+		try {
+			if (this.configDir != null) {
+				this.logger.info( "Monitoring is stopping..." );
+				this.configDir = null;
+				this.applications.clear();
+
+				// The template watcher is going to be stopped.
+				resetTemplateWatcher();
+				this.logger.info( "Monitoring is stopped!" );
+			}
+		} finally {
+			this.lock.writeLock().unlock();
+		}
+	}
+
+	/**
+	 * Do nothing if monitoring is started, fail otherwise.
+	 *
+	 * @throws IllegalStateException if monitoring is not started.
+	 * @GuardedBy this.lock
+	 */
+	private void ensureMonitoringIsStarted() {
+		if (this.configDir == null) {
+			throw new IllegalStateException( "monitoring not started" );
+		}
+	}
+
+	@Override
+	public void addApplication( final Application app ) {
+		// First create the monitored application entry.
+		final String name = app.getName();
+		final MonitoredApplication monitoredApp = new MonitoredApplication( app );
+		final boolean added;
+		this.lock.writeLock().lock();
+		try {
+			ensureMonitoringIsStarted();
+			// Check if the application is already in the map.
+			if (!this.applications.containsKey( name )) {
+				// Add the monitored application entry.
+				this.applications.put( name, monitoredApp );
+				added = true;
+				this.logger.info( "Monitored application has been added: " + name );
+			} else {
+				added = false;
+			}
+		} finally {
+			this.lock.writeLock().unlock();
+		}
+		// Refresh the application's context & generate reports, outside of the lock.
+		if (added) {
+			processApplication( monitoredApp );
+		}
+	}
+
+	@Override
+	public void updateApplication( final Application app ) {
+		final String name = app.getName();
+		final MonitoredApplication monitored;
+		this.lock.readLock().lock();
+		try {
+			ensureMonitoringIsStarted();
+			monitored = this.applications.get( name );
+		} finally {
+			this.lock.readLock().unlock();
+		}
+		// Refresh the application's context & generate reports, outside of the lock.
+		if (monitored != null) {
+			this.logger.info( "Monitored application is being updated: " + name );
+			processApplication( monitored );
+		}
+	}
+
+	@Override
+	public void removeApplication( final Application app ) {
+		final String name = app.getName();
+		this.lock.writeLock().lock();
+		try {
+			ensureMonitoringIsStarted();
+			// Check if the application is already is the map.
+			if (this.applications.containsKey( name )) {
+				this.applications.remove( name );
+				this.logger.info( "Monitored application has been removed: " + name );
+			}
+		} finally {
+			this.lock.writeLock().unlock();
+		}
+	}
+
+	//
+	// Template processing methods.
+	//
+
+	/**
+	 * Generates the monitoring reports for all the applications, for the given templates.
+	 *
+	 * <p>Called by the template watcher when templates appear or are modified.</p>
+	 *
+	 * @param templates the template to process.
+	 */
+	public void processTemplates( final Collection<TemplateEntry> templates ) {
+		this.logger.info( "Processing templates: " + templates + "..." );
+		// Get the monitoring contexts for each application.
+		final Map<String, Context> contexts = new HashMap<String, Context>();
+		final File targetDir;
+		this.lock.readLock().lock();
+		try {
+			targetDir = this.targetDir;
+			if (targetDir != null) {
+				for (final MonitoredApplication app : this.applications.values()) {
+					contexts.put( app.getModel().getName(), app.getCurrentContext() );
+				}
+			} else {
+				this.logger.warning( "Target directory is not configured, cannot process templates!" );
+			}
+		} finally {
+			this.lock.readLock().unlock();
+		}
+		// For each template to process...
+		for (final TemplateEntry templateEntry : templates) {
+			if (templateEntry.appName != null) {
+				// Application-specific template, only apply the scoped application context (if it exists).
+				final Context appContext = contexts.get( templateEntry.appName );
+				if (appContext != null) {
+					process( templateEntry.appName, appContext, templateEntry, targetDir );
+				} else {
+					this.logger.finest("Cannot process template " + templateEntry + ": application " +
+							templateEntry.appName + " is not monitored");
+				}
+			} else {
+				// Global template, apply each one of the existing application contexts.
+				for (final Entry<String, Context> contextEntry : contexts.entrySet()) {
+					process( contextEntry.getKey(), contextEntry.getValue(), templateEntry, targetDir );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Generates all the monitoring reports for the given application.
+	 *
+	 * <p>Called by the add/updateApplication methods.</p>
+	 *
+	 * @param app the application.
+	 */
+	private void processApplication( final MonitoredApplication app ) {
+		final String name = app.getModel().getName();
+		final Context context;
+		final Collection<TemplateEntry> templates;
+		final File targetDir;
+		this.lock.readLock().lock();
+		try {
+			if (this.templateWatcher != null) {
+				templates = this.templateWatcher.getTemplates( name );
+				targetDir = this.targetDir;
+			} else {
+				templates = null;
+				targetDir = null;
+			}
+			context = app.getCurrentContext();
+		} finally {
+			this.lock.readLock().unlock();
+		}
+		// Process outside of the lock.
+		if (templates != null) {
+			if (!templates.isEmpty()) {
+				for (final TemplateEntry templateEntry : templates) {
+					process( name, context, templateEntry, targetDir );
+				}
+			} else {
+				logger.fine( "No template to process for application " + name );
+			}
+		} else {
+			logger.warning( "Template watcher is disabled. No template can be retrieved for application " + name );
+		}
+	}
+
+	/**
+	 * Generate the monitoring reports for one application using one template.
+	 *
+	 * @param appName the name of the application
+	 * @param context the monitoring context of the application.
+	 * @param templateEntry the monitoring template entry.
+	 * @param targetDir the monitoring report target directory.
+	 */
+	private void process( final String appName, final Context context, final TemplateEntry templateEntry,
+						  final File targetDir ) {
+		// Compute the target file location:
+		// - targetDir/appName/templateId for app-specific templates,
+		// - targetDir/appName.templateId for global templates.
+		final File parentDir;
+		final File targetFile;
+		if (templateEntry.appName != null) {
+			parentDir = new File( targetDir, appName );
+			targetFile = new File( parentDir, templateEntry.id );
+		} else {
+			parentDir = targetDir;
+			targetFile = new File( targetDir, appName + '.' + templateEntry.id );
+		}
+
+		try {
+			this.logger.fine( "Applying template " + templateEntry.id + " to application " + appName + "..." );
+
+			// Apply the context to the template.
+			final String output = templateEntry.template.apply( context );
+			// Create the parent directory, as it may not yet exist.
+			Utils.createDirectory( parentDir );
+			// Write the content to the target file.
+			Utils.writeStringInto( output, targetFile );
+
+		} catch (final IOException e) {
+			this.logger.warning( "Cannot apply template " + templateEntry.id + " to application " + appName );
+			Utils.logException( this.logger, e );
+		} catch (final HandlebarsException e) {
+			this.logger.warning( "Cannot apply template " + templateEntry.id + " to application " + appName );
+			Utils.logException( this.logger, e );
+		} catch (final Throwable e) {
+			this.logger.warning( "Cannot apply template " + templateEntry.id + " to application " + appName );
+			Utils.logException( this.logger, new UndeclaredThrowableException( e ) );
+		}
+	}
+
+	//
+	// MonitoringService methods
+	//
+
+	@Override
+	public File getTargetDirectory() {
+		this.lock.readLock().lock();
+		try {
+			return this.targetDir;
+		} finally {
+			this.lock.readLock().unlock();
+		}
+	}
+
+	/**
+	 * Get the template directory for the given application.
+	 *
+	 * @param application the application whose template directory must be retrieved, or {@code null} to get the global
+	 *                    template directory.
+	 * @return the template directory for the given application, or the global template directory if the
+	 * {@code application} parameter is set to {@code null}.
+	 */
+	private File getTemplateDirectory( final Application application ) {
+		// Get the current template directory.
+		final File templateDir;
+		this.lock.readLock().lock();
+		try {
+			templateDir = this.templateDir;
+		} finally {
+			this.lock.readLock().unlock();
+		}
+		// Append the application name, if not null.
+		final File result;
+		if (application != null) {
+			result = new File( templateDir, application.getName() );
+		} else {
+			result = templateDir;
+		}
+		return result;
+	}
+
+	@Override
+	public boolean addTemplate( final Application application, final String name, final InputStream content )
+			throws IOException {
+		Objects.requireNonNull( name, "name is null" );
+		Objects.requireNonNull( content, "content is null" );
+		final File templateDir = getTemplateDirectory( application );
+		// Directory may not yet exist, create it!
+		Utils.createDirectory( templateDir );
+
+		// Check if the template exists.
+		final boolean added;
+		final File template = new File( templateDir, name + MONITORING_TEMPLATE_FILE_EXTENSION );
+		if (!template.exists()) {
+			// Copy the template!
+			Utils.copyStream( content, template );
+			added = true;
+		} else {
+			added = false;
+		}
+		return added;
+	}
+
+	@Override
+	public Set<String> listTemplates( final Application application ) {
+		final File templateDir = getTemplateDirectory( application );
+		// List the files, using the exact same filter the watcher uses/would use.
+		final File[] templateFiles = templateDir.listFiles(
+				(FileFilter) FileFilterUtils.and(
+						FileFilterUtils.fileFileFilter(),
+						FileFilterUtils.suffixFileFilter( MonitoringService.MONITORING_TEMPLATE_FILE_EXTENSION ),
+						CanReadFileFilter.CAN_READ ) );
+		// Extract the identifiers from the templates.
+		Set<String> templateNames;
+		if (templateFiles != null && templateFiles.length > 0) {
+			templateNames = new HashSet<String>();
+			for (final File templateFile : templateFiles) {
+				// Add the template file name, but remove the ".tpl" extension.
+				final String name = templateFile.getName();
+				templateNames.add( name.substring( 0, name.length() - MONITORING_TEMPLATE_FILE_EXTENSION.length() ) );
+			}
+			templateNames = Collections.unmodifiableSet( templateNames );
+		} else {
+			templateNames = Collections.emptySet();
+		}
+		return templateNames;
+	}
+
+	@Override
+	public boolean removeTemplate( final Application application, final String name ) throws IOException {
+		Objects.requireNonNull( name, "name is null" );
+		final File template = new File( getTemplateDirectory( application ),
+				name + MONITORING_TEMPLATE_FILE_EXTENSION );
+		return template.exists() && template.isFile() && template.delete();
+	}
+
+}

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/TemplateEntry.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/TemplateEntry.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring.internal;
+
+import java.io.File;
+import java.io.FileFilter;
+
+import com.github.jknack.handlebars.Template;
+import net.roboconf.dm.monitoring.MonitoringService;
+import org.apache.commons.io.filefilter.AbstractFileFilter;
+import org.apache.commons.io.filefilter.CanReadFileFilter;
+import org.apache.commons.io.filefilter.FileFilterUtils;
+
+/**
+ * Entry for a template being watched by the {@link TemplateWatcher}.
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public final class TemplateEntry {
+
+	/**
+	 * The template file.
+	 */
+	final File file;
+
+	/**
+	 * The identifier of this template entry.
+	 */
+	final String id;
+
+	/**
+	 * The name of the application scoped by this template, or {@code null} for a global template entry.
+	 */
+	final String appName;
+
+	/**
+	 * The compiled Handlebars template.
+	 */
+	final Template template;
+
+	/**
+	 * Get the file filter for monitoring templates selection inside the given template directory.
+	 *
+	 * Templates must:
+	 * <ol>
+	 * <li>be regular templates,</li>
+	 * <li>have the monitoring template file extension,</li>
+	 * <li>be readable,</li>
+	 * <li>be :
+	 * <ul>
+	 * <li>either <em>direct children</em> of the template directory. In that case the templates are global
+	 * to all applications.</li>
+	 * <li>or be grandchildren of the template directory. In that case, the templates are specific to one
+	 * application, the name of the intermediate directory being the name of the application.</li>
+	 * </ul>
+	 * </li>
+	 * </ol>
+	 *
+	 * @param templateDir the monitoring template directory, <em>MUST</em> be canonical.
+	 * @return the file filter for monitoring template selection inside the given directory.
+	 */
+	public static FileFilter getTemplateFileFilter( final File templateDir ) {
+		return FileFilterUtils.or(
+				FileFilterUtils.and(
+						FileFilterUtils.fileFileFilter(),
+						FileFilterUtils.suffixFileFilter( MonitoringService.MONITORING_TEMPLATE_FILE_EXTENSION ),
+						CanReadFileFilter.CAN_READ,
+						new AbstractFileFilter() {
+							@Override
+							public boolean accept( File file ) {
+								final File parentDir = file.getParentFile();
+								return templateDir.equals( parentDir ) || templateDir.equals( parentDir.getParentFile() );
+							}
+						} ),
+				FileFilterUtils.and(
+						FileFilterUtils.directoryFileFilter(),
+						CanReadFileFilter.CAN_READ,
+						new AbstractFileFilter() {
+							@Override
+							public boolean accept( File file ) {
+								return templateDir.equals( file.getParentFile() );
+							}
+						} )
+				);
+	}
+
+	/**
+	 * Get the name of the application targeted by a template from its filename.
+	 *
+	 * @param templateDir  the monitoring template root directory, the one being watched by the TemplateWatcher.
+	 * @param templateFile the template file
+	 * @return name of the application targeted by the given template file, or {@code null} for a template global to all
+	 * applications.
+	 * @throws IllegalStateException if the provided {@code templateFile} does not match
+	 */
+	public static String getTemplateApplicationName( final File templateDir, final File templateFile ) {
+		if (!templateFile.getName().endsWith( MonitoringService.MONITORING_TEMPLATE_FILE_EXTENSION )) {
+			throw new IllegalArgumentException( "not a template file name: " + templateFile.getName() );
+		}
+		final File parentDir = templateFile.getParentFile();
+		final String appName;
+		if (templateDir.equals( parentDir )) {
+			// No intermediate directory, the template is global!
+			appName = null;
+		} else if (templateDir.equals( parentDir.getParentFile() )) {
+			// One intermediate directory: the template is specific to one application.
+			// The name of the application is the name of the intermediate directory.
+			appName = parentDir.getName();
+		} else {
+			// Too many levels!
+			throw new IllegalArgumentException( "not a template file: " + templateFile );
+		}
+		return appName;
+	}
+
+	/**
+	 * Create a template entry.
+	 *
+	 * @param file     the template file.
+	 * @param id       tThe identifier of this template entry.
+	 * @param appName  the name of the application scoped by this template, or {@code null} for a global template
+	 *                 entry.
+	 * @param template the compiled Handlebars template.
+	 */
+	public TemplateEntry( final File file, final String id, final String appName, final Template template ) {
+		this.file = file;
+		this.id = id;
+		this.appName = appName;
+		this.template = template;
+	}
+
+	/**
+	 * Get the identifier of a template from its filename.
+	 *
+	 * @param templateFile the template file
+	 * @return the identifier for the given template file.
+	 * @throws IllegalArgumentException if the provided template file does not end with the template file extension.
+	 */
+	public static String getTemplateId( final File templateFile ) {
+		final String name = templateFile.getName();
+		if (!name.endsWith( MonitoringService.MONITORING_TEMPLATE_FILE_EXTENSION )) {
+			throw new IllegalArgumentException( "not a template file name: " + name );
+		}
+		return name.substring( 0, name.length() - MonitoringService.MONITORING_TEMPLATE_FILE_EXTENSION.length() );
+	}
+
+	@Override
+	public String toString() {
+		return super.toString() + "[appName=" + this.appName + ", id=" + this.id + ", file=" + this.file + "]";
+	}
+
+}

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/TemplateWatcher.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/TemplateWatcher.java
@@ -1,0 +1,360 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.logging.Logger;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.HandlebarsException;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.io.StringTemplateSource;
+import net.roboconf.core.utils.Utils;
+import net.roboconf.dm.monitoring.MonitoringService;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.AbstractFileFilter;
+import org.apache.commons.io.filefilter.CanReadFileFilter;
+import org.apache.commons.io.filefilter.FileFilterUtils;
+import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
+import org.apache.commons.io.monitor.FileAlterationMonitor;
+import org.apache.commons.io.monitor.FileAlterationObserver;
+
+/**
+ * A file system watcher dedicated to the Roboconf application templates.
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public class TemplateWatcher extends FileAlterationListenerAdaptor {
+
+	/**
+	 * The monitoring manager.
+	 */
+	private final MonitoringManager manager;
+
+	/**
+	 * The monitoring template directory.
+	 */
+	private final File templateDir;
+
+	/**
+	 * The template alteration monitor.
+	 */
+	private final FileAlterationMonitor monitor;
+
+	/**
+	 * Flag indicating if this watcher has already tracked down the templates already present in the template
+	 * directory.
+	 */
+	private AtomicBoolean hasBeenProvisioned = new AtomicBoolean( false );
+
+	/**
+	 * The lock for keeping watched templates.
+	 */
+	private final ReadWriteLock lock = new ReentrantReadWriteLock( true );
+
+	/**
+	 * The templates being watched, index by the name of the scoped application (or {@code null} for global templates)
+	 * and then by the template identifier.
+	 *
+	 * @GuardedBy lock
+	 */
+	private final Map<String, Map<String, TemplateEntry>> templates = new HashMap<String, Map<String, TemplateEntry>>();
+
+	/**
+	 * The Handlebars template processor.
+	 */
+	private final Handlebars handlebars = new Handlebars();
+
+	/**
+	 * The logger.
+	 */
+	private final Logger logger = Logger.getLogger( this.getClass().getName() );
+
+	/**
+	 * Create a template watcher.
+	 *
+	 * @param manager      the monitoring manager, to which event handling is delegated.
+	 * @param templateDir  the monitoring template directory to watch.
+	 * @param pollInterval the poll interval.
+	 * @throws IOException if there is a problem watching the template directory.
+	 */
+	public TemplateWatcher( final MonitoringManager manager, final File templateDir, final long pollInterval )
+			throws IOException {
+		this.manager = manager;
+
+		// Register the custom helpers.
+		this.handlebars.registerHelper( AllHelper.NAME, AllHelper.INSTANCE );
+
+		// We need the canonical directory, in order to test relationship w/ monitoring template candidates.
+		this.templateDir = templateDir.getCanonicalFile();
+
+		// Create the observer, register this object as the event listener.
+		final FileAlterationObserver observer = new FileAlterationObserver(
+				this.templateDir, TemplateEntry.getTemplateFileFilter( this.templateDir ) );
+		observer.addListener( this );
+
+		// Create the monitor.
+		this.monitor = new FileAlterationMonitor( pollInterval, observer );
+		this.monitor.setThreadFactory( new ThreadFactory() {
+			@Override
+			public Thread newThread( final Runnable r ) {
+				return new Thread( r, "Roboconf.TemplateWatcher" );
+			}
+		} );
+
+		this.logger.fine( "Template watcher configured with templateDir=" + this.templateDir.toString()
+				+ " and pollInterval=" + pollInterval );
+	}
+
+	/**
+	 * Start this template watcher.
+	 *
+	 * @GuardedBy this.manager.globalLock.writeLock()
+	 */
+	public void start() {
+		try {
+			this.monitor.start();
+		} catch (final Exception e) {
+			this.logger.warning( "Cannot start template watcher" );
+			Utils.logException( this.logger, e );
+		}
+	}
+
+	/**
+	 * Stop this template watcher.
+	 *
+	 * @GuardedBy this.manager.globalLock.writeLock()
+	 */
+	public void stop() {
+		try {
+			this.monitor.stop();
+		} catch (final Exception e) {
+			this.logger.warning( "Cannot stop template watcher" );
+			Utils.logException( this.logger, e );
+		}
+	}
+
+	/**
+	 * Get the list of the templates currently tracked, for the application with the given name.
+	 *
+	 * <p>The templates contained in the returned set may have been removed at the time they are accessed.</p>
+	 *
+	 * @param appName the name of the application, or {@code null} to only get the global templates.
+	 * @return the templates scoping the application with the given name, <em>including</em> the global templates.
+	 */
+	public Collection<TemplateEntry> getTemplates( final String appName ) {
+		this.lock.readLock().lock();
+		try {
+			final Collection<TemplateEntry> result = new ArrayList<TemplateEntry>();
+			// Process the application-specific templates.
+			if (appName != null) {
+				Map<String, TemplateEntry> appSpecificTemplates = this.templates.get( appName );
+				if (appSpecificTemplates != null) {
+					result.addAll( appSpecificTemplates.values() );
+				}
+			}
+			// Process the global templates.
+			Map<String, TemplateEntry> globalTemplates = this.templates.get( null );
+			if (globalTemplates != null) {
+				result.addAll( globalTemplates.values() );
+			}
+			return Collections.unmodifiableCollection( result );
+		} finally {
+			this.lock.readLock().unlock();
+		}
+	}
+
+	/**
+	 * Compile the given template file and create the associated template entry.
+	 *
+	 * <p>IO and compile errors are logged but not rethrown.</p>
+	 *
+	 * @param templateFile the template file to compile.
+	 * @return the created template entry, or {@code null} if any problem has occurred.
+	 */
+	private TemplateEntry compileTemplate( final File templateFile ) {
+		TemplateEntry templateEntry = null;
+		try {
+			// Compile the template file.
+			final Template template = handlebars.compile(
+					new StringTemplateSource(
+							templateFile.toString(),
+							Utils.readFileContent( templateFile ) ) );
+			// Create the entry.
+			templateEntry = new TemplateEntry(
+					templateFile,
+					TemplateEntry.getTemplateId( templateFile ),
+					TemplateEntry.getTemplateApplicationName( templateDir, templateFile ),
+					template );
+		} catch (final IOException e) {
+			this.logger.warning( "Cannot compile template " + templateFile );
+			Utils.logException( this.logger, e );
+		} catch (final IllegalArgumentException e) {
+			this.logger.warning( "Cannot compile template " + templateFile );
+			Utils.logException( this.logger, e );
+		} catch (final HandlebarsException e) {
+			this.logger.warning( "Cannot compile template " + templateFile );
+			Utils.logException( this.logger, e );
+		}
+		return templateEntry;
+	}
+
+	/**
+	 * Add/update the given template entry in the {@code templates} map.
+	 *
+	 * @param templateEntry the template entry to add/update.
+	 * @GuardedBy this.lock.writeLock()
+	 */
+	private void updateTemplateEntry( final TemplateEntry templateEntry ) {
+		Map<String, TemplateEntry> specificTemplates = this.templates.get( templateEntry.appName );
+		if (specificTemplates == null) {
+			specificTemplates = new HashMap<String, TemplateEntry>();
+			this.templates.put( templateEntry.appName, specificTemplates );
+		}
+		specificTemplates.put( templateEntry.id, templateEntry );
+	}
+
+	//
+	// FileAlterationListener methods.
+	//
+
+	@Override
+	public void onStart( final FileAlterationObserver observer ) {
+		if (!this.hasBeenProvisioned.getAndSet( true )) {
+			// We must list the templates already present in the directory, as they won't otherwise trigger any event,
+			// and thus be ignored.
+			this.logger.fine( "Initial provisioning of templates..." );
+
+			// Find all the template files: the global *and* the specific ones.
+			final Collection<File> templateFiles = FileUtils.listFiles(
+					this.templateDir,
+					// Regular file filter:
+					// List readable files with the template extension.
+					FileFilterUtils.and(
+							FileFilterUtils.suffixFileFilter( MonitoringService.MONITORING_TEMPLATE_FILE_EXTENSION ),
+							CanReadFileFilter.CAN_READ ),
+					// Directory filter:
+					// Go through the root template directory and its direct children.
+					new AbstractFileFilter() {
+						@Override
+						public boolean accept( final File file ) {
+							return templateDir.equals( file ) || templateDir.equals( file.getParentFile() );
+						}
+					} );
+
+			// Compile all the template files, outside of the critical section.
+			final Collection<TemplateEntry> templateEntries = new ArrayList<TemplateEntry>();
+			for (final File templateFile : templateFiles) {
+				final TemplateEntry templateEntry = compileTemplate( templateFile );
+				if (templateEntry != null) {
+					templateEntries.add( templateEntry );
+					this.logger.finest( "++ Added " + templateEntry );
+				}
+			}
+
+			// Add all the template entries.
+			this.lock.writeLock().lock();
+			try {
+				for (final TemplateEntry templateEntry : templateEntries) {
+					updateTemplateEntry( templateEntry );
+				}
+			} finally {
+				this.lock.writeLock().unlock();
+			}
+			// Notify the manager, outside of the lock.
+			this.manager.processTemplates( templateEntries );
+		}
+	}
+
+	@Override
+	public void onFileCreate( final File file ) {
+		// Compile the template file, outside of the critical section.
+		final TemplateEntry templateEntry = compileTemplate( file );
+		if (templateEntry != null) {
+
+			// Update the template map.
+			this.lock.writeLock().lock();
+			try {
+				updateTemplateEntry( templateEntry );
+				this.logger.finest( "++ Added " + templateEntry );
+			} finally {
+				this.lock.writeLock().unlock();
+			}
+			// Notify the manager, outside of the critical section.
+			this.manager.processTemplates( Collections.singletonList( templateEntry ) );
+		}
+	}
+
+	@Override
+	public void onFileChange( final File file ) {
+		// Compile the template file, outside of the critical section.
+		final TemplateEntry templateEntry = compileTemplate( file );
+		if (templateEntry != null) {
+
+			// Update the template map.
+			this.lock.writeLock().lock();
+			try {
+				updateTemplateEntry( templateEntry );
+				this.logger.finest( "!! Updated " + file );
+			} finally {
+				this.lock.writeLock().unlock();
+			}
+			// Notify the manager, outside of the critical section.
+			this.manager.processTemplates( Collections.singletonList( templateEntry ) );
+		}
+	}
+
+	@Override
+	public void onFileDelete( final File file ) {
+		final String appName = TemplateEntry.getTemplateApplicationName( this.templateDir, file );
+		final String id = TemplateEntry.getTemplateId( file );
+		this.lock.writeLock().lock();
+		try {
+			Map<String, TemplateEntry> specificTemplates = this.templates.get( appName );
+			if (specificTemplates != null) {
+				specificTemplates.remove( id );
+				if (specificTemplates.isEmpty()) {
+					this.templates.remove( appName );
+				}
+			}
+			this.logger.finest( "-- Removed " + file );
+		} finally {
+			this.lock.writeLock().unlock();
+		}
+		// The manager does not need to be notified.
+	}
+
+}

--- a/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/VariableContextBean.java
+++ b/core/roboconf-dm-monitoring/src/main/java/net/roboconf/dm/monitoring/internal/VariableContextBean.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring.internal;
+
+/**
+ * Context bean for an imported/exported variable.
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public class VariableContextBean {
+	String name;
+	String value;
+
+	public String getName() {
+		return this.name;
+	}
+
+	public String getValue() {
+		return this.value;
+	}
+
+	@Override
+	public String toString() {
+		return this.name + '=' + this.value;
+	}
+}

--- a/core/roboconf-dm-monitoring/src/main/resources/OSGI-INF/bundle.info
+++ b/core/roboconf-dm-monitoring/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,7 @@
+\u001B[1mSYNOPSIS\u001B[0m
+    This bundle is part of the Roboconf project.
+
+\u001B[1mDESCRIPTION\u001B[0m
+    The DM (Deployment Manager) monitoring generates monitoring reports driven by
+    user-defined templates. It watches the Roboconf configuration directory for templates
+    and generates and updates reports when the state of an application changes.

--- a/core/roboconf-dm-monitoring/src/test/java/net/roboconf/dm/monitoring/internal/MonitoringContextTest.java
+++ b/core/roboconf-dm-monitoring/src/test/java/net/roboconf/dm/monitoring/internal/MonitoringContextTest.java
@@ -1,0 +1,326 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring.internal;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import net.roboconf.core.internal.tests.TestUtils;
+import net.roboconf.core.model.RuntimeModelIo;
+import net.roboconf.core.model.RuntimeModelIo.ApplicationLoadResult;
+import org.junit.Before;
+import org.junit.Test;
+
+import static net.roboconf.core.model.beans.Instance.InstanceStatus.NOT_DEPLOYED;
+import static net.roboconf.dm.monitoring.internal.MonitoringTestUtils.instancesByPath;
+import static net.roboconf.dm.monitoring.internal.MonitoringTestUtils.variableMapOf;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.MapAssert.entry;
+
+/**
+ * Test the monitoring context computed by the {@link MonitoringManager}.
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public class MonitoringContextTest {
+
+	/**
+	 * The monitoring context of the application being tested.
+	 */
+	private ApplicationContextBean context;
+
+	/**
+	 * The paths of the instances indexed by type.
+	 */
+	private Map<String, Set<String>> instancesOf = new LinkedHashMap<String, Set<String>>();
+
+	/**
+	 * The monitoring context of the instances, indexed by path.
+	 */
+	private Map<String, InstanceContextBean> instanceContexts = new LinkedHashMap<String, InstanceContextBean>(  );
+
+	@Before
+	public void before() throws IOException, URISyntaxException {
+		// Load the application from the test resources.
+		final ApplicationLoadResult result = RuntimeModelIo.loadApplication( TestUtils.findTestFile( "/example-app" ) );
+		assertThat( result.getApplication() ).isNotNull();
+		context = MonitoredApplication.applicationContext( result.getApplication() );
+
+		instanceContexts = instancesByPath(context.getInstances());
+
+		// We need to re-arrange the data for easier further access.
+		for (final Entry<String, Set<InstanceContextBean>> entry : context.getInstancesByType().entrySet()) {
+			final Set<String> instancesOfType = new LinkedHashSet<String>();
+			for (final InstanceContextBean i : entry.getValue()) {
+				instancesOfType.add( i.getPath() );
+			}
+			instancesOf.put( entry.getKey(), instancesOfType );
+		}
+		
+		
+		
+	}
+
+	@Test
+	public void testName() {
+		assertThat( context.getName() ).isEqualTo( "example-app" );
+	}
+
+	@Test
+	public void testDescription() {
+		assertThat( context.getDescription() ).isEqualTo( "An example application" );
+	}
+
+	@Test
+	public void testComponents() {
+		assertThat( context.getComponents() ).containsOnly( "Vm", "MySql", "Apache", "Tomcat", "War" );
+	}
+
+	@Test
+	public void testInstancesByType() {
+		assertThat( instancesOf.get( "Vm" ) )
+				.containsOnly( "/MySqlVm", "/ApacheVm", "/TomcatVm1", "/TomcatVm2" );
+		assertThat( instancesOf.get( "Virtual" ) )
+				.containsOnly( "/MySqlVm", "/ApacheVm", "/TomcatVm1", "/TomcatVm2" );
+		assertThat( instancesOf.get( "Machine" ) )
+				.containsOnly( "/MySqlVm", "/ApacheVm", "/TomcatVm1", "/TomcatVm2" );
+
+		assertThat( instancesOf.get( "MySql" ) )
+				.containsOnly( "/MySqlVm/MySql" );
+		assertThat( instancesOf.get( "Apache" ) )
+				.containsOnly( "/ApacheVm/Apache" );
+		assertThat( instancesOf.get( "Tomcat" ) )
+				.containsOnly( "/TomcatVm1/Tomcat", "/TomcatVm2/Tomcat" );
+		assertThat( instancesOf.get( "Service" ) )
+				.containsOnly( "/MySqlVm/MySql", "/ApacheVm/Apache", "/TomcatVm1/Tomcat", "/TomcatVm2/Tomcat" );
+		assertThat( instancesOf.get( "NetworkService" ) )
+				.containsOnly( "/MySqlVm/MySql", "/ApacheVm/Apache", "/TomcatVm1/Tomcat", "/TomcatVm2/Tomcat" );
+
+		assertThat( instancesOf.get( "War" ) )
+				.containsOnly( "/TomcatVm1/Tomcat/WebApp", "/TomcatVm2/Tomcat/WebApp" );
+		assertThat( instancesOf.get( "Application" ) )
+				.containsOnly( "/TomcatVm1/Tomcat/WebApp", "/TomcatVm2/Tomcat/WebApp" );
+	}
+	
+	@Test
+	public void testMySqlVmInstance() {
+		final InstanceContextBean instance = instanceContexts.get( "/MySqlVm" );
+		assertThat( instance.getName() ).isEqualTo( "MySqlVm" );
+		assertThat( instance.getPath() ).isEqualTo( "/MySqlVm" );
+		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
+		assertThat( instance.getStatusIsStable() ).isTrue();
+		assertThat( instance.getComponent() ).isEqualTo( "Vm" );
+		assertThat( instance.getTypes() ).containsOnly( "Vm", "Virtual", "Machine", "VirtualMachine" );
+		assertThat( instance.getParent() ).isNull();
+		assertThat( instance.getChildren() ).containsOnly( instanceContexts.get( "/MySqlVm/MySql" ) );
+		assertThat( instance.getIp() ).isNull();
+		assertThat( instance.getInstaller() ).isEqualTo( "target" );
+		assertThat( instance.getExports() ).isEmpty();
+		assertThat( instance.getImports() ).isEmpty();
+		assertThat( variableMapOf( instance.getData() ))
+				.hasSize( 1 ).includes( entry( "application.name", "example-app" ) );
+	}
+
+	@Test
+	public void testApacheVmInstance() {
+		final InstanceContextBean instance = instanceContexts.get( "/ApacheVm" );
+		assertThat( instance.getName() ).isEqualTo( "ApacheVm" );
+		assertThat( instance.getPath() ).isEqualTo( "/ApacheVm" );
+		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
+		assertThat( instance.getStatusIsStable() ).isTrue();
+		assertThat( instance.getComponent() ).isEqualTo( "Vm" );
+		assertThat( instance.getTypes() ).containsOnly( "Vm", "Virtual", "Machine", "VirtualMachine" );
+		assertThat( instance.getParent() ).isNull();
+		assertThat( instance.getChildren() ).containsOnly( instanceContexts.get( "/ApacheVm/Apache" ) );
+		assertThat( instance.getIp() ).isNull();
+		assertThat( instance.getInstaller() ).isEqualTo( "target" );
+		assertThat( instance.getExports() ).isEmpty();
+		assertThat( instance.getImports() ).isEmpty();
+		assertThat( variableMapOf( instance.getData() ))
+				.hasSize( 1 ).includes( entry( "application.name", "example-app" ) );
+	}
+
+	@Test
+	public void testTomcatVmInstance1() {
+		final InstanceContextBean instance = instanceContexts.get( "/TomcatVm1" );
+		assertThat( instance.getName() ).isEqualTo( "TomcatVm1" );
+		assertThat( instance.getPath() ).isEqualTo( "/TomcatVm1" );
+		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
+		assertThat( instance.getStatusIsStable() ).isTrue();
+		assertThat( instance.getComponent() ).isEqualTo( "Vm" );
+		assertThat( instance.getTypes() ).containsOnly( "Vm", "Virtual", "Machine", "VirtualMachine" );
+		assertThat( instance.getParent() ).isNull();
+		assertThat( instance.getChildren() ).containsOnly( instanceContexts.get( "/TomcatVm1/Tomcat" ) );
+		assertThat( instance.getIp() ).isNull();
+		assertThat( instance.getInstaller() ).isEqualTo( "target" );
+		assertThat( instance.getExports() ).isEmpty();
+		assertThat( instance.getImports() ).isEmpty();
+		assertThat( variableMapOf( instance.getData() ))
+				.hasSize( 1 ).includes( entry( "application.name", "example-app" ) );
+	}
+
+	@Test
+	public void testTomcatVmInstance2() {
+		final InstanceContextBean instance = instanceContexts.get( "/TomcatVm2" );
+		assertThat( instance.getName() ).isEqualTo( "TomcatVm2" );
+		assertThat( instance.getPath() ).isEqualTo( "/TomcatVm2" );
+		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
+		assertThat( instance.getStatusIsStable() ).isTrue();
+		assertThat( instance.getComponent() ).isEqualTo( "Vm" );
+		assertThat( instance.getTypes() ).containsOnly( "Vm", "Virtual", "Machine", "VirtualMachine" );
+		assertThat( instance.getParent() ).isNull();
+		assertThat( instance.getChildren() ).containsOnly( instanceContexts.get( "/TomcatVm2/Tomcat" ) );
+		assertThat( instance.getIp() ).isNull();
+		assertThat( instance.getInstaller() ).isEqualTo( "target" );
+		assertThat( instance.getExports() ).isEmpty();
+		assertThat( instance.getImports() ).isEmpty();
+		assertThat( variableMapOf( instance.getData() ))
+				.hasSize( 1 ).includes( entry( "application.name", "example-app" ) );
+	}
+
+	@Test
+	public void testMySqlInstance() {
+		final InstanceContextBean instance = instanceContexts.get( "/MySqlVm/MySql" );
+		assertThat( instance.getName() ).isEqualTo( "MySql" );
+		assertThat( instance.getPath() ).isEqualTo( "/MySqlVm/MySql" );
+		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
+		assertThat( instance.getStatusIsStable() ).isTrue();
+		assertThat( instance.getComponent() ).isEqualTo( "MySql" );
+		assertThat( instance.getTypes() ).containsOnly( "MySql", "NetworkService", "Service" );
+		assertThat( instance.getParent() ).isSameAs( instanceContexts.get( "/MySqlVm" ) );
+		assertThat( instance.getChildren() ).isEmpty();
+		assertThat( instance.getIp() ).isNull();
+		assertThat( instance.getInstaller() ).isEqualTo( "puppet" );
+		final Map<String, String> exports = variableMapOf( instance.getExports() );
+		assertThat( exports ).hasSize( 2 );
+		assertThat(exports.get( "MySql.ip" )).isNull();
+		assertThat(exports.get( "MySql.port" )).isEqualTo( "3306" );
+		assertThat( instance.getImports() ).isEmpty();
+		assertThat( instance.getData() ).isEmpty();
+	}
+
+	@Test
+	public void testApacheInstance() {
+		final InstanceContextBean instance = instanceContexts.get( "/ApacheVm/Apache" );
+		assertThat( instance.getName() ).isEqualTo( "Apache" );
+		assertThat( instance.getPath() ).isEqualTo( "/ApacheVm/Apache" );
+		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
+		assertThat( instance.getStatusIsStable() ).isTrue();
+		assertThat( instance.getComponent() ).isEqualTo( "Apache" );
+		assertThat( instance.getTypes() ).containsOnly( "Apache", "NetworkService", "Service" );
+		assertThat( instance.getParent() ).isSameAs( instanceContexts.get( "/ApacheVm" ) );
+		assertThat( instance.getChildren() ).isEmpty();
+		assertThat( instance.getIp() ).isNull();
+		assertThat( instance.getInstaller() ).isEqualTo( "script" );
+		assertThat( instance.getExports() ).isEmpty();
+		assertThat( instance.getImports() ).isEmpty();
+		assertThat( instance.getData()).isEmpty();
+	}
+
+	@Test
+	public void testTomcatInstance1() {
+		final InstanceContextBean instance = instanceContexts.get( "/TomcatVm1/Tomcat" );
+		assertThat( instance.getName() ).isEqualTo( "Tomcat" );
+		assertThat( instance.getPath() ).isEqualTo( "/TomcatVm1/Tomcat" );
+		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
+		assertThat( instance.getStatusIsStable() ).isTrue();
+		assertThat( instance.getComponent() ).isEqualTo( "Tomcat" );
+		assertThat( instance.getTypes() ).containsOnly( "Tomcat", "NetworkService", "Service" );
+		assertThat( instance.getParent() ).isSameAs( instanceContexts.get( "/TomcatVm1" ) );
+		assertThat( instance.getChildren() ).containsOnly( instanceContexts.get( "/TomcatVm1/Tomcat/WebApp" ));
+		assertThat( instance.getIp() ).isNull();
+		assertThat( instance.getInstaller() ).isEqualTo( "docker" );
+		final Map<String, String> exports = variableMapOf( instance.getExports() );
+		assertThat( exports ).hasSize( 2 );
+		assertThat(exports.get( "Tomcat.ip" )).isNull();
+		assertThat(exports.get( "Tomcat.ajpPort" )).isEqualTo( "9021" );
+		assertThat( instance.getImports() ).isEmpty();
+		assertThat( instance.getData()).isEmpty();
+	}
+
+	@Test
+	public void testTomcatInstance2() {
+		final InstanceContextBean instance = instanceContexts.get( "/TomcatVm2/Tomcat" );
+		assertThat( instance.getName() ).isEqualTo( "Tomcat" );
+		assertThat( instance.getPath() ).isEqualTo( "/TomcatVm2/Tomcat" );
+		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
+		assertThat( instance.getStatusIsStable() ).isTrue();
+		assertThat( instance.getComponent() ).isEqualTo( "Tomcat" );
+		assertThat( instance.getTypes() ).containsOnly( "Tomcat", "NetworkService", "Service" );
+		assertThat( instance.getParent() ).isSameAs( instanceContexts.get( "/TomcatVm2" ) );
+		assertThat( instance.getChildren() ).containsOnly( instanceContexts.get( "/TomcatVm2/Tomcat/WebApp" ));
+		assertThat( instance.getIp() ).isNull();
+		assertThat( instance.getInstaller() ).isEqualTo( "docker" );
+		final Map<String, String> exports = variableMapOf( instance.getExports() );
+		assertThat( exports ).hasSize( 2 );
+		assertThat(exports.get( "Tomcat.ip" )).isNull();
+		assertThat(exports.get( "Tomcat.ajpPort" )).isEqualTo( "9021" );
+		assertThat( instance.getImports() ).isEmpty();
+		assertThat( instance.getData()).isEmpty();
+	}
+
+	@Test
+	public void testWebAppInstance1() {
+		final InstanceContextBean instance = instanceContexts.get( "/TomcatVm1/Tomcat/WebApp" );
+		assertThat( instance.getName() ).isEqualTo( "WebApp" );
+		assertThat( instance.getPath() ).isEqualTo( "/TomcatVm1/Tomcat/WebApp" );
+		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
+		assertThat( instance.getStatusIsStable() ).isTrue();
+		assertThat( instance.getComponent() ).isEqualTo( "War" );
+		assertThat( instance.getTypes() ).containsOnly( "War", "Application" );
+		assertThat( instance.getParent() ).isSameAs( instanceContexts.get( "/TomcatVm1/Tomcat" ) );
+		assertThat( instance.getChildren() ).isEmpty();
+		assertThat( instance.getIp() ).isNull();
+		assertThat( instance.getInstaller() ).isEqualTo( "human" );
+		assertThat( instance.getExports() ).isEmpty();
+		assertThat( instance.getImports() ).isEmpty();
+		assertThat( instance.getData()).isEmpty();
+	}
+
+	@Test
+	public void testWebAppInstance2() {
+		final InstanceContextBean instance = instanceContexts.get( "/TomcatVm2/Tomcat/WebApp" );
+		assertThat( instance.getName() ).isEqualTo( "WebApp" );
+		assertThat( instance.getPath() ).isEqualTo( "/TomcatVm2/Tomcat/WebApp" );
+		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
+		assertThat( instance.getStatusIsStable() ).isTrue();
+		assertThat( instance.getComponent() ).isEqualTo( "War" );
+		assertThat( instance.getTypes() ).containsOnly( "War", "Application" );
+		assertThat( instance.getParent() ).isSameAs( instanceContexts.get( "/TomcatVm2/Tomcat" ) );
+		assertThat( instance.getChildren() ).isEmpty();
+		assertThat( instance.getIp() ).isNull();
+		assertThat( instance.getInstaller() ).isEqualTo( "human" );
+		assertThat( instance.getExports() ).isEmpty();
+		assertThat( instance.getImports() ).isEmpty();
+		assertThat( instance.getData()).isEmpty();
+	}
+	
+}

--- a/core/roboconf-dm-monitoring/src/test/java/net/roboconf/dm/monitoring/internal/MonitoringContextTest.java
+++ b/core/roboconf-dm-monitoring/src/test/java/net/roboconf/dm/monitoring/internal/MonitoringContextTest.java
@@ -65,14 +65,14 @@ public class MonitoringContextTest {
 	/**
 	 * The monitoring context of the instances, indexed by path.
 	 */
-	private Map<String, InstanceContextBean> instanceContexts = new LinkedHashMap<String, InstanceContextBean>(  );
+	private Map<String, InstanceContextBean> instanceContexts = new LinkedHashMap<String, InstanceContextBean>();
 
 	@Before
 	public void before() throws IOException, URISyntaxException {
 		// Load the application from the test resources.
-		final ApplicationLoadResult result = RuntimeModelIo.loadApplication( TestUtils.findTestFile( "/example-app" ) );
-		assertThat( result.getApplication() ).isNotNull();
-		context = MonitoredApplication.applicationContext( result.getApplication() );
+		final ApplicationLoadResult result = RuntimeModelIo.loadApplication(TestUtils.findTestFile("/example-app"));
+		assertThat(result.getApplication()).isNotNull();
+		context = MonitoredApplication.applicationContext(result.getApplication());
 
 		instanceContexts = instancesByPath(context.getInstances());
 
@@ -80,247 +80,246 @@ public class MonitoringContextTest {
 		for (final Entry<String, Set<InstanceContextBean>> entry : context.getInstancesByType().entrySet()) {
 			final Set<String> instancesOfType = new LinkedHashSet<String>();
 			for (final InstanceContextBean i : entry.getValue()) {
-				instancesOfType.add( i.getPath() );
+				instancesOfType.add(i.getPath());
 			}
-			instancesOf.put( entry.getKey(), instancesOfType );
+			instancesOf.put(entry.getKey(), instancesOfType);
 		}
-		
-		
-		
+
+
 	}
 
 	@Test
 	public void testName() {
-		assertThat( context.getName() ).isEqualTo( "example-app" );
+		assertThat(context.getName()).isEqualTo("example-app");
 	}
 
 	@Test
 	public void testDescription() {
-		assertThat( context.getDescription() ).isEqualTo( "An example application" );
+		assertThat(context.getDescription()).isEqualTo("An example application");
 	}
 
 	@Test
 	public void testComponents() {
-		assertThat( context.getComponents() ).containsOnly( "Vm", "MySql", "Apache", "Tomcat", "War" );
+		assertThat(context.getComponents()).containsOnly("Vm", "MySql", "Apache", "Tomcat", "War");
 	}
 
 	@Test
 	public void testInstancesByType() {
-		assertThat( instancesOf.get( "Vm" ) )
-				.containsOnly( "/MySqlVm", "/ApacheVm", "/TomcatVm1", "/TomcatVm2" );
-		assertThat( instancesOf.get( "Virtual" ) )
-				.containsOnly( "/MySqlVm", "/ApacheVm", "/TomcatVm1", "/TomcatVm2" );
-		assertThat( instancesOf.get( "Machine" ) )
-				.containsOnly( "/MySqlVm", "/ApacheVm", "/TomcatVm1", "/TomcatVm2" );
+		assertThat(instancesOf.get("Vm"))
+				.containsOnly("/MySqlVm", "/ApacheVm", "/TomcatVm1", "/TomcatVm2");
+		assertThat(instancesOf.get("Virtual"))
+				.containsOnly("/MySqlVm", "/ApacheVm", "/TomcatVm1", "/TomcatVm2");
+		assertThat(instancesOf.get("Machine"))
+				.containsOnly("/MySqlVm", "/ApacheVm", "/TomcatVm1", "/TomcatVm2");
 
-		assertThat( instancesOf.get( "MySql" ) )
-				.containsOnly( "/MySqlVm/MySql" );
-		assertThat( instancesOf.get( "Apache" ) )
-				.containsOnly( "/ApacheVm/Apache" );
-		assertThat( instancesOf.get( "Tomcat" ) )
-				.containsOnly( "/TomcatVm1/Tomcat", "/TomcatVm2/Tomcat" );
-		assertThat( instancesOf.get( "Service" ) )
-				.containsOnly( "/MySqlVm/MySql", "/ApacheVm/Apache", "/TomcatVm1/Tomcat", "/TomcatVm2/Tomcat" );
-		assertThat( instancesOf.get( "NetworkService" ) )
-				.containsOnly( "/MySqlVm/MySql", "/ApacheVm/Apache", "/TomcatVm1/Tomcat", "/TomcatVm2/Tomcat" );
+		assertThat(instancesOf.get("MySql"))
+				.containsOnly("/MySqlVm/MySql");
+		assertThat(instancesOf.get("Apache"))
+				.containsOnly("/ApacheVm/Apache");
+		assertThat(instancesOf.get("Tomcat"))
+				.containsOnly("/TomcatVm1/Tomcat", "/TomcatVm2/Tomcat");
+		assertThat(instancesOf.get("Service"))
+				.containsOnly("/MySqlVm/MySql", "/ApacheVm/Apache", "/TomcatVm1/Tomcat", "/TomcatVm2/Tomcat");
+		assertThat(instancesOf.get("NetworkService"))
+				.containsOnly("/MySqlVm/MySql", "/ApacheVm/Apache", "/TomcatVm1/Tomcat", "/TomcatVm2/Tomcat");
 
-		assertThat( instancesOf.get( "War" ) )
-				.containsOnly( "/TomcatVm1/Tomcat/WebApp", "/TomcatVm2/Tomcat/WebApp" );
-		assertThat( instancesOf.get( "Application" ) )
-				.containsOnly( "/TomcatVm1/Tomcat/WebApp", "/TomcatVm2/Tomcat/WebApp" );
+		assertThat(instancesOf.get("War"))
+				.containsOnly("/TomcatVm1/Tomcat/WebApp", "/TomcatVm2/Tomcat/WebApp");
+		assertThat(instancesOf.get("Application"))
+				.containsOnly("/TomcatVm1/Tomcat/WebApp", "/TomcatVm2/Tomcat/WebApp");
 	}
-	
+
 	@Test
 	public void testMySqlVmInstance() {
-		final InstanceContextBean instance = instanceContexts.get( "/MySqlVm" );
-		assertThat( instance.getName() ).isEqualTo( "MySqlVm" );
-		assertThat( instance.getPath() ).isEqualTo( "/MySqlVm" );
-		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
-		assertThat( instance.getStatusIsStable() ).isTrue();
-		assertThat( instance.getComponent() ).isEqualTo( "Vm" );
-		assertThat( instance.getTypes() ).containsOnly( "Vm", "Virtual", "Machine", "VirtualMachine" );
-		assertThat( instance.getParent() ).isNull();
-		assertThat( instance.getChildren() ).containsOnly( instanceContexts.get( "/MySqlVm/MySql" ) );
-		assertThat( instance.getIp() ).isNull();
-		assertThat( instance.getInstaller() ).isEqualTo( "target" );
-		assertThat( instance.getExports() ).isEmpty();
-		assertThat( instance.getImports() ).isEmpty();
-		assertThat( variableMapOf( instance.getData() ))
-				.hasSize( 1 ).includes( entry( "application.name", "example-app" ) );
+		final InstanceContextBean instance = instanceContexts.get("/MySqlVm");
+		assertThat(instance.getName()).isEqualTo("MySqlVm");
+		assertThat(instance.getPath()).isEqualTo("/MySqlVm");
+		assertThat(instance.getStatus()).isEqualTo(NOT_DEPLOYED);
+		assertThat(instance.getStatusIsStable()).isTrue();
+		assertThat(instance.getComponent()).isEqualTo("Vm");
+		assertThat(instance.getTypes()).containsOnly("Vm", "Virtual", "Machine", "VirtualMachine");
+		assertThat(instance.getParent()).isNull();
+		assertThat(instance.getChildren()).containsOnly(instanceContexts.get("/MySqlVm/MySql"));
+		assertThat(instance.getIp()).isNull();
+		assertThat(instance.getInstaller()).isEqualTo("target");
+		assertThat(instance.getExports()).isEmpty();
+		assertThat(instance.getImports()).isEmpty();
+		assertThat(variableMapOf(instance.getData()))
+				.hasSize(1).includes(entry("application.name", "example-app"));
 	}
 
 	@Test
 	public void testApacheVmInstance() {
-		final InstanceContextBean instance = instanceContexts.get( "/ApacheVm" );
-		assertThat( instance.getName() ).isEqualTo( "ApacheVm" );
-		assertThat( instance.getPath() ).isEqualTo( "/ApacheVm" );
-		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
-		assertThat( instance.getStatusIsStable() ).isTrue();
-		assertThat( instance.getComponent() ).isEqualTo( "Vm" );
-		assertThat( instance.getTypes() ).containsOnly( "Vm", "Virtual", "Machine", "VirtualMachine" );
-		assertThat( instance.getParent() ).isNull();
-		assertThat( instance.getChildren() ).containsOnly( instanceContexts.get( "/ApacheVm/Apache" ) );
-		assertThat( instance.getIp() ).isNull();
-		assertThat( instance.getInstaller() ).isEqualTo( "target" );
-		assertThat( instance.getExports() ).isEmpty();
-		assertThat( instance.getImports() ).isEmpty();
-		assertThat( variableMapOf( instance.getData() ))
-				.hasSize( 1 ).includes( entry( "application.name", "example-app" ) );
+		final InstanceContextBean instance = instanceContexts.get("/ApacheVm");
+		assertThat(instance.getName()).isEqualTo("ApacheVm");
+		assertThat(instance.getPath()).isEqualTo("/ApacheVm");
+		assertThat(instance.getStatus()).isEqualTo(NOT_DEPLOYED);
+		assertThat(instance.getStatusIsStable()).isTrue();
+		assertThat(instance.getComponent()).isEqualTo("Vm");
+		assertThat(instance.getTypes()).containsOnly("Vm", "Virtual", "Machine", "VirtualMachine");
+		assertThat(instance.getParent()).isNull();
+		assertThat(instance.getChildren()).containsOnly(instanceContexts.get("/ApacheVm/Apache"));
+		assertThat(instance.getIp()).isNull();
+		assertThat(instance.getInstaller()).isEqualTo("target");
+		assertThat(instance.getExports()).isEmpty();
+		assertThat(instance.getImports()).isEmpty();
+		assertThat(variableMapOf(instance.getData()))
+				.hasSize(1).includes(entry("application.name", "example-app"));
 	}
 
 	@Test
 	public void testTomcatVmInstance1() {
-		final InstanceContextBean instance = instanceContexts.get( "/TomcatVm1" );
-		assertThat( instance.getName() ).isEqualTo( "TomcatVm1" );
-		assertThat( instance.getPath() ).isEqualTo( "/TomcatVm1" );
-		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
-		assertThat( instance.getStatusIsStable() ).isTrue();
-		assertThat( instance.getComponent() ).isEqualTo( "Vm" );
-		assertThat( instance.getTypes() ).containsOnly( "Vm", "Virtual", "Machine", "VirtualMachine" );
-		assertThat( instance.getParent() ).isNull();
-		assertThat( instance.getChildren() ).containsOnly( instanceContexts.get( "/TomcatVm1/Tomcat" ) );
-		assertThat( instance.getIp() ).isNull();
-		assertThat( instance.getInstaller() ).isEqualTo( "target" );
-		assertThat( instance.getExports() ).isEmpty();
-		assertThat( instance.getImports() ).isEmpty();
-		assertThat( variableMapOf( instance.getData() ))
-				.hasSize( 1 ).includes( entry( "application.name", "example-app" ) );
+		final InstanceContextBean instance = instanceContexts.get("/TomcatVm1");
+		assertThat(instance.getName()).isEqualTo("TomcatVm1");
+		assertThat(instance.getPath()).isEqualTo("/TomcatVm1");
+		assertThat(instance.getStatus()).isEqualTo(NOT_DEPLOYED);
+		assertThat(instance.getStatusIsStable()).isTrue();
+		assertThat(instance.getComponent()).isEqualTo("Vm");
+		assertThat(instance.getTypes()).containsOnly("Vm", "Virtual", "Machine", "VirtualMachine");
+		assertThat(instance.getParent()).isNull();
+		assertThat(instance.getChildren()).containsOnly(instanceContexts.get("/TomcatVm1/Tomcat"));
+		assertThat(instance.getIp()).isNull();
+		assertThat(instance.getInstaller()).isEqualTo("target");
+		assertThat(instance.getExports()).isEmpty();
+		assertThat(instance.getImports()).isEmpty();
+		assertThat(variableMapOf(instance.getData()))
+				.hasSize(1).includes(entry("application.name", "example-app"));
 	}
 
 	@Test
 	public void testTomcatVmInstance2() {
-		final InstanceContextBean instance = instanceContexts.get( "/TomcatVm2" );
-		assertThat( instance.getName() ).isEqualTo( "TomcatVm2" );
-		assertThat( instance.getPath() ).isEqualTo( "/TomcatVm2" );
-		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
-		assertThat( instance.getStatusIsStable() ).isTrue();
-		assertThat( instance.getComponent() ).isEqualTo( "Vm" );
-		assertThat( instance.getTypes() ).containsOnly( "Vm", "Virtual", "Machine", "VirtualMachine" );
-		assertThat( instance.getParent() ).isNull();
-		assertThat( instance.getChildren() ).containsOnly( instanceContexts.get( "/TomcatVm2/Tomcat" ) );
-		assertThat( instance.getIp() ).isNull();
-		assertThat( instance.getInstaller() ).isEqualTo( "target" );
-		assertThat( instance.getExports() ).isEmpty();
-		assertThat( instance.getImports() ).isEmpty();
-		assertThat( variableMapOf( instance.getData() ))
-				.hasSize( 1 ).includes( entry( "application.name", "example-app" ) );
+		final InstanceContextBean instance = instanceContexts.get("/TomcatVm2");
+		assertThat(instance.getName()).isEqualTo("TomcatVm2");
+		assertThat(instance.getPath()).isEqualTo("/TomcatVm2");
+		assertThat(instance.getStatus()).isEqualTo(NOT_DEPLOYED);
+		assertThat(instance.getStatusIsStable()).isTrue();
+		assertThat(instance.getComponent()).isEqualTo("Vm");
+		assertThat(instance.getTypes()).containsOnly("Vm", "Virtual", "Machine", "VirtualMachine");
+		assertThat(instance.getParent()).isNull();
+		assertThat(instance.getChildren()).containsOnly(instanceContexts.get("/TomcatVm2/Tomcat"));
+		assertThat(instance.getIp()).isNull();
+		assertThat(instance.getInstaller()).isEqualTo("target");
+		assertThat(instance.getExports()).isEmpty();
+		assertThat(instance.getImports()).isEmpty();
+		assertThat(variableMapOf(instance.getData()))
+				.hasSize(1).includes(entry("application.name", "example-app"));
 	}
 
 	@Test
 	public void testMySqlInstance() {
-		final InstanceContextBean instance = instanceContexts.get( "/MySqlVm/MySql" );
-		assertThat( instance.getName() ).isEqualTo( "MySql" );
-		assertThat( instance.getPath() ).isEqualTo( "/MySqlVm/MySql" );
-		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
-		assertThat( instance.getStatusIsStable() ).isTrue();
-		assertThat( instance.getComponent() ).isEqualTo( "MySql" );
-		assertThat( instance.getTypes() ).containsOnly( "MySql", "NetworkService", "Service" );
-		assertThat( instance.getParent() ).isSameAs( instanceContexts.get( "/MySqlVm" ) );
-		assertThat( instance.getChildren() ).isEmpty();
-		assertThat( instance.getIp() ).isNull();
-		assertThat( instance.getInstaller() ).isEqualTo( "puppet" );
-		final Map<String, String> exports = variableMapOf( instance.getExports() );
-		assertThat( exports ).hasSize( 2 );
-		assertThat(exports.get( "MySql.ip" )).isNull();
-		assertThat(exports.get( "MySql.port" )).isEqualTo( "3306" );
-		assertThat( instance.getImports() ).isEmpty();
-		assertThat( instance.getData() ).isEmpty();
+		final InstanceContextBean instance = instanceContexts.get("/MySqlVm/MySql");
+		assertThat(instance.getName()).isEqualTo("MySql");
+		assertThat(instance.getPath()).isEqualTo("/MySqlVm/MySql");
+		assertThat(instance.getStatus()).isEqualTo(NOT_DEPLOYED);
+		assertThat(instance.getStatusIsStable()).isTrue();
+		assertThat(instance.getComponent()).isEqualTo("MySql");
+		assertThat(instance.getTypes()).containsOnly("MySql", "NetworkService", "Service");
+		assertThat(instance.getParent()).isSameAs(instanceContexts.get("/MySqlVm"));
+		assertThat(instance.getChildren()).isEmpty();
+		assertThat(instance.getIp()).isNull();
+		assertThat(instance.getInstaller()).isEqualTo("puppet");
+		final Map<String, String> exports = variableMapOf(instance.getExports());
+		assertThat(exports).hasSize(2);
+		assertThat(exports.get("MySql.ip")).isNull();
+		assertThat(exports.get("MySql.port")).isEqualTo("3306");
+		assertThat(instance.getImports()).isEmpty();
+		assertThat(instance.getData()).isEmpty();
 	}
 
 	@Test
 	public void testApacheInstance() {
-		final InstanceContextBean instance = instanceContexts.get( "/ApacheVm/Apache" );
-		assertThat( instance.getName() ).isEqualTo( "Apache" );
-		assertThat( instance.getPath() ).isEqualTo( "/ApacheVm/Apache" );
-		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
-		assertThat( instance.getStatusIsStable() ).isTrue();
-		assertThat( instance.getComponent() ).isEqualTo( "Apache" );
-		assertThat( instance.getTypes() ).containsOnly( "Apache", "NetworkService", "Service" );
-		assertThat( instance.getParent() ).isSameAs( instanceContexts.get( "/ApacheVm" ) );
-		assertThat( instance.getChildren() ).isEmpty();
-		assertThat( instance.getIp() ).isNull();
-		assertThat( instance.getInstaller() ).isEqualTo( "script" );
-		assertThat( instance.getExports() ).isEmpty();
-		assertThat( instance.getImports() ).isEmpty();
-		assertThat( instance.getData()).isEmpty();
+		final InstanceContextBean instance = instanceContexts.get("/ApacheVm/Apache");
+		assertThat(instance.getName()).isEqualTo("Apache");
+		assertThat(instance.getPath()).isEqualTo("/ApacheVm/Apache");
+		assertThat(instance.getStatus()).isEqualTo(NOT_DEPLOYED);
+		assertThat(instance.getStatusIsStable()).isTrue();
+		assertThat(instance.getComponent()).isEqualTo("Apache");
+		assertThat(instance.getTypes()).containsOnly("Apache", "NetworkService", "Service");
+		assertThat(instance.getParent()).isSameAs(instanceContexts.get("/ApacheVm"));
+		assertThat(instance.getChildren()).isEmpty();
+		assertThat(instance.getIp()).isNull();
+		assertThat(instance.getInstaller()).isEqualTo("script");
+		assertThat(instance.getExports()).isEmpty();
+		assertThat(instance.getImports()).isEmpty();
+		assertThat(instance.getData()).isEmpty();
 	}
 
 	@Test
 	public void testTomcatInstance1() {
-		final InstanceContextBean instance = instanceContexts.get( "/TomcatVm1/Tomcat" );
-		assertThat( instance.getName() ).isEqualTo( "Tomcat" );
-		assertThat( instance.getPath() ).isEqualTo( "/TomcatVm1/Tomcat" );
-		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
-		assertThat( instance.getStatusIsStable() ).isTrue();
-		assertThat( instance.getComponent() ).isEqualTo( "Tomcat" );
-		assertThat( instance.getTypes() ).containsOnly( "Tomcat", "NetworkService", "Service" );
-		assertThat( instance.getParent() ).isSameAs( instanceContexts.get( "/TomcatVm1" ) );
-		assertThat( instance.getChildren() ).containsOnly( instanceContexts.get( "/TomcatVm1/Tomcat/WebApp" ));
-		assertThat( instance.getIp() ).isNull();
-		assertThat( instance.getInstaller() ).isEqualTo( "docker" );
-		final Map<String, String> exports = variableMapOf( instance.getExports() );
-		assertThat( exports ).hasSize( 2 );
-		assertThat(exports.get( "Tomcat.ip" )).isNull();
-		assertThat(exports.get( "Tomcat.ajpPort" )).isEqualTo( "9021" );
-		assertThat( instance.getImports() ).isEmpty();
-		assertThat( instance.getData()).isEmpty();
+		final InstanceContextBean instance = instanceContexts.get("/TomcatVm1/Tomcat");
+		assertThat(instance.getName()).isEqualTo("Tomcat");
+		assertThat(instance.getPath()).isEqualTo("/TomcatVm1/Tomcat");
+		assertThat(instance.getStatus()).isEqualTo(NOT_DEPLOYED);
+		assertThat(instance.getStatusIsStable()).isTrue();
+		assertThat(instance.getComponent()).isEqualTo("Tomcat");
+		assertThat(instance.getTypes()).containsOnly("Tomcat", "NetworkService", "Service");
+		assertThat(instance.getParent()).isSameAs(instanceContexts.get("/TomcatVm1"));
+		assertThat(instance.getChildren()).containsOnly(instanceContexts.get("/TomcatVm1/Tomcat/WebApp"));
+		assertThat(instance.getIp()).isNull();
+		assertThat(instance.getInstaller()).isEqualTo("docker");
+		final Map<String, String> exports = variableMapOf(instance.getExports());
+		assertThat(exports).hasSize(2);
+		assertThat(exports.get("Tomcat.ip")).isNull();
+		assertThat(exports.get("Tomcat.ajpPort")).isEqualTo("9021");
+		assertThat(instance.getImports()).isEmpty();
+		assertThat(instance.getData()).isEmpty();
 	}
 
 	@Test
 	public void testTomcatInstance2() {
-		final InstanceContextBean instance = instanceContexts.get( "/TomcatVm2/Tomcat" );
-		assertThat( instance.getName() ).isEqualTo( "Tomcat" );
-		assertThat( instance.getPath() ).isEqualTo( "/TomcatVm2/Tomcat" );
-		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
-		assertThat( instance.getStatusIsStable() ).isTrue();
-		assertThat( instance.getComponent() ).isEqualTo( "Tomcat" );
-		assertThat( instance.getTypes() ).containsOnly( "Tomcat", "NetworkService", "Service" );
-		assertThat( instance.getParent() ).isSameAs( instanceContexts.get( "/TomcatVm2" ) );
-		assertThat( instance.getChildren() ).containsOnly( instanceContexts.get( "/TomcatVm2/Tomcat/WebApp" ));
-		assertThat( instance.getIp() ).isNull();
-		assertThat( instance.getInstaller() ).isEqualTo( "docker" );
-		final Map<String, String> exports = variableMapOf( instance.getExports() );
-		assertThat( exports ).hasSize( 2 );
-		assertThat(exports.get( "Tomcat.ip" )).isNull();
-		assertThat(exports.get( "Tomcat.ajpPort" )).isEqualTo( "9021" );
-		assertThat( instance.getImports() ).isEmpty();
-		assertThat( instance.getData()).isEmpty();
+		final InstanceContextBean instance = instanceContexts.get("/TomcatVm2/Tomcat");
+		assertThat(instance.getName()).isEqualTo("Tomcat");
+		assertThat(instance.getPath()).isEqualTo("/TomcatVm2/Tomcat");
+		assertThat(instance.getStatus()).isEqualTo(NOT_DEPLOYED);
+		assertThat(instance.getStatusIsStable()).isTrue();
+		assertThat(instance.getComponent()).isEqualTo("Tomcat");
+		assertThat(instance.getTypes()).containsOnly("Tomcat", "NetworkService", "Service");
+		assertThat(instance.getParent()).isSameAs(instanceContexts.get("/TomcatVm2"));
+		assertThat(instance.getChildren()).containsOnly(instanceContexts.get("/TomcatVm2/Tomcat/WebApp"));
+		assertThat(instance.getIp()).isNull();
+		assertThat(instance.getInstaller()).isEqualTo("docker");
+		final Map<String, String> exports = variableMapOf(instance.getExports());
+		assertThat(exports).hasSize(2);
+		assertThat(exports.get("Tomcat.ip")).isNull();
+		assertThat(exports.get("Tomcat.ajpPort")).isEqualTo("9021");
+		assertThat(instance.getImports()).isEmpty();
+		assertThat(instance.getData()).isEmpty();
 	}
 
 	@Test
 	public void testWebAppInstance1() {
-		final InstanceContextBean instance = instanceContexts.get( "/TomcatVm1/Tomcat/WebApp" );
-		assertThat( instance.getName() ).isEqualTo( "WebApp" );
-		assertThat( instance.getPath() ).isEqualTo( "/TomcatVm1/Tomcat/WebApp" );
-		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
-		assertThat( instance.getStatusIsStable() ).isTrue();
-		assertThat( instance.getComponent() ).isEqualTo( "War" );
-		assertThat( instance.getTypes() ).containsOnly( "War", "Application" );
-		assertThat( instance.getParent() ).isSameAs( instanceContexts.get( "/TomcatVm1/Tomcat" ) );
-		assertThat( instance.getChildren() ).isEmpty();
-		assertThat( instance.getIp() ).isNull();
-		assertThat( instance.getInstaller() ).isEqualTo( "human" );
-		assertThat( instance.getExports() ).isEmpty();
-		assertThat( instance.getImports() ).isEmpty();
-		assertThat( instance.getData()).isEmpty();
+		final InstanceContextBean instance = instanceContexts.get("/TomcatVm1/Tomcat/WebApp");
+		assertThat(instance.getName()).isEqualTo("WebApp");
+		assertThat(instance.getPath()).isEqualTo("/TomcatVm1/Tomcat/WebApp");
+		assertThat(instance.getStatus()).isEqualTo(NOT_DEPLOYED);
+		assertThat(instance.getStatusIsStable()).isTrue();
+		assertThat(instance.getComponent()).isEqualTo("War");
+		assertThat(instance.getTypes()).containsOnly("War", "Application");
+		assertThat(instance.getParent()).isSameAs(instanceContexts.get("/TomcatVm1/Tomcat"));
+		assertThat(instance.getChildren()).isEmpty();
+		assertThat(instance.getIp()).isNull();
+		assertThat(instance.getInstaller()).isEqualTo("human");
+		assertThat(instance.getExports()).isEmpty();
+		assertThat(instance.getImports()).isEmpty();
+		assertThat(instance.getData()).isEmpty();
 	}
 
 	@Test
 	public void testWebAppInstance2() {
-		final InstanceContextBean instance = instanceContexts.get( "/TomcatVm2/Tomcat/WebApp" );
-		assertThat( instance.getName() ).isEqualTo( "WebApp" );
-		assertThat( instance.getPath() ).isEqualTo( "/TomcatVm2/Tomcat/WebApp" );
-		assertThat( instance.getStatus() ).isEqualTo( NOT_DEPLOYED );
-		assertThat( instance.getStatusIsStable() ).isTrue();
-		assertThat( instance.getComponent() ).isEqualTo( "War" );
-		assertThat( instance.getTypes() ).containsOnly( "War", "Application" );
-		assertThat( instance.getParent() ).isSameAs( instanceContexts.get( "/TomcatVm2/Tomcat" ) );
-		assertThat( instance.getChildren() ).isEmpty();
-		assertThat( instance.getIp() ).isNull();
-		assertThat( instance.getInstaller() ).isEqualTo( "human" );
-		assertThat( instance.getExports() ).isEmpty();
-		assertThat( instance.getImports() ).isEmpty();
-		assertThat( instance.getData()).isEmpty();
+		final InstanceContextBean instance = instanceContexts.get("/TomcatVm2/Tomcat/WebApp");
+		assertThat(instance.getName()).isEqualTo("WebApp");
+		assertThat(instance.getPath()).isEqualTo("/TomcatVm2/Tomcat/WebApp");
+		assertThat(instance.getStatus()).isEqualTo(NOT_DEPLOYED);
+		assertThat(instance.getStatusIsStable()).isTrue();
+		assertThat(instance.getComponent()).isEqualTo("War");
+		assertThat(instance.getTypes()).containsOnly("War", "Application");
+		assertThat(instance.getParent()).isSameAs(instanceContexts.get("/TomcatVm2/Tomcat"));
+		assertThat(instance.getChildren()).isEmpty();
+		assertThat(instance.getIp()).isNull();
+		assertThat(instance.getInstaller()).isEqualTo("human");
+		assertThat(instance.getExports()).isEmpty();
+		assertThat(instance.getImports()).isEmpty();
+		assertThat(instance.getData()).isEmpty();
 	}
-	
+
 }

--- a/core/roboconf-dm-monitoring/src/test/java/net/roboconf/dm/monitoring/internal/MonitoringManagerTest.java
+++ b/core/roboconf-dm-monitoring/src/test/java/net/roboconf/dm/monitoring/internal/MonitoringManagerTest.java
@@ -1,0 +1,247 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring.internal;
+
+import java.io.File;
+import java.io.IOException;
+
+import net.roboconf.core.model.beans.Application;
+import net.roboconf.core.model.beans.Graphs;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static net.roboconf.dm.monitoring.MonitoringService.MONITORING_TARGET_DIRECTORY;
+import static net.roboconf.dm.monitoring.MonitoringService.MONITORING_TEMPLATE_DIRECTORY;
+import static net.roboconf.dm.monitoring.internal.MonitoringTestUtils.addStringTemplate;
+import static net.roboconf.dm.monitoring.internal.MonitoringTestUtils.hasContent;
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Test the {@link net.roboconf.dm.monitoring.internal.MonitoringManager} component.
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public class MonitoringManagerTest {
+
+	/**
+	 * The template watcher poll interval.
+	 * <p>
+	 * If some tests fail erratically, this interval should be increased.
+	 * </p>
+	 */
+	private static long POLL_INTERVAL = 250L;
+
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
+
+	/**
+	 * The tested {@code MonitoringManager} component.
+	 */
+	private MonitoringManager manager;
+
+	/**
+	 * The Monitoring manager template directory.
+	 */
+	private File templateDir;
+
+	/**
+	 * The Monitoring manager target directory.
+	 */
+	private File targetDir;
+
+	/**
+	 * A sample application.
+	 */
+	private final Application app1 = new Application()
+			.name( "test-app-1" )
+			.description( "An application being tested" )
+			.qualifier( "test" )
+			.graphs( new Graphs() );
+
+	/**
+	 * Another sample application.
+	 */
+	private final Application app2 = new Application()
+			.name( "test-app-2" )
+			.description( "Another application being tested" )
+			.qualifier( "test" )
+			.graphs( new Graphs() );
+
+	@Before
+	public void before() throws IOException {
+		// Create the configuration directory.
+		final File configDir = tmpDir.newFolder();
+		templateDir = new File( configDir, MONITORING_TEMPLATE_DIRECTORY );
+		targetDir = new File( configDir, MONITORING_TARGET_DIRECTORY );
+
+		// Create & configure the monitoring manager component.
+		manager = new MonitoringManager();
+		manager.setPollInterval( POLL_INTERVAL );
+		manager.start();
+		manager.startMonitoring( configDir );
+
+		// Add the applications
+		manager.addApplication( app1 );
+		manager.addApplication( app2 );
+	}
+
+	@After
+	public void after() throws IOException {
+		// Remove the applications
+		manager.removeApplication( app1 );
+		manager.removeApplication( app2 );
+
+		manager.stopMonitoring();
+		manager.stop();
+	}
+
+	@Test
+	public void testRootDirectoriesAreCreated() {
+		assertThat( templateDir ).exists().isDirectory();
+		assertThat( targetDir ).exists().isDirectory();
+	}
+
+	@Test
+	public void testGlobalAndSpecificTemplates() throws IOException, InterruptedException {
+		// Add global & local (app-specific) templates.
+		addStringTemplate( manager, null, "global.test", "global:{{name}}" );
+		addStringTemplate( manager, app1, "local1.test", "app1:{{name}}" );
+		addStringTemplate( manager, app2, "local2.test", "app2:{{name}}" );
+
+		// Check the templates are here.
+		assertThat( manager.listTemplates( null ) ).containsOnly( "global.test" );
+		assertThat( manager.listTemplates( app1 ) ).containsOnly( "local1.test" );
+		assertThat( manager.listTemplates( app2 ) ).containsOnly( "local2.test" );
+
+		// Wait for a while, so the reports are generated.
+		Thread.sleep( 2 * POLL_INTERVAL );
+
+		// Check the presence and the content of the global monitoring reports.
+		assertThat( new File( targetDir, "test-app-1.global.test" ) )
+				.exists()
+				.isFile()
+				.satisfies( hasContent( "global:test-app-1" ) );
+		assertThat( new File( targetDir, "test-app-2.global.test" ) )
+				.exists()
+				.isFile()
+				.satisfies( hasContent( "global:test-app-2" ) );
+
+		// Check the presence and the content of the local monitoring reports.
+		assertThat( new File( targetDir, "test-app-1" + File.separatorChar + "local1.test" ) )
+				.exists()
+				.isFile()
+				.satisfies( hasContent( "app1:test-app-1" ) );
+		assertThat( new File( targetDir, "test-app-2" + File.separatorChar + "local2.test" ) )
+				.exists()
+				.isFile()
+				.satisfies( hasContent( "app2:test-app-2" ) );
+
+		// Remove the applications
+		manager.removeApplication( app1 );
+		manager.removeApplication( app2 );
+	}
+
+	@Test
+	public void testUpdateApplication() throws IOException, InterruptedException {
+		// Add global & local (app-specific) templates.
+		addStringTemplate( manager, null, "global.test", "global:{{description}}" );
+		addStringTemplate( manager, app1, "local1.test", "app1:{{description}}" );
+
+		final File global = new File( targetDir, "test-app-1.global.test" );
+		final File local = new File( targetDir, "test-app-1" + File.separatorChar + "local1.test" );
+
+		// Wait for a while, so the reports are generated.
+		Thread.sleep( 2 * POLL_INTERVAL );
+
+		// Check the presence and the content of the global monitoring reports.
+		assertThat( global ).exists().isFile().satisfies( hasContent( "global:An application being tested" ) );
+
+		// Check the presence and the content of the local monitoring reports.
+		assertThat( local ).exists().isFile().satisfies( hasContent( "app1:An application being tested" ) );
+
+		// Change the application, check, update, and recheck!
+		app1.setDescription( "CHANGED!" );
+
+		// Wait for a while... just in case an (unwanted) update occurs.
+		Thread.sleep( 2 * POLL_INTERVAL );
+
+		// Should not have changed!
+		assertThat( global ).satisfies( hasContent( "global:An application being tested" ) );
+		assertThat( local ).satisfies( hasContent( "app1:An application being tested" ) );
+
+		// Update the application, the reports should be updated synchronously.
+		manager.updateApplication( app1 );
+		assertThat( global ).satisfies( hasContent( "global:CHANGED!" ) );
+		assertThat( local ).satisfies( hasContent( "app1:CHANGED!" ) );
+	}
+
+	@Test
+	public void testRemoveApplication() throws IOException, InterruptedException {
+		// Add global & local (app-specific) templates.
+		addStringTemplate( manager, null, "global.test", "global:{{description}}" );
+		addStringTemplate( manager, app1, "local.test", "local:{{description}}" );
+
+		final File global = new File( targetDir, "test-app-1.global.test" );
+		final File local = new File( targetDir, "test-app-1" + File.separatorChar + "local.test" );
+
+		// Wait for a while, so the reports are generated.
+		Thread.sleep( 2 * POLL_INTERVAL );
+
+		// Check the presence and the content monitoring reports.
+		assertThat( global ).exists().isFile().satisfies( hasContent( "global:An application being tested" ) );
+		assertThat( local ).exists().isFile().satisfies( hasContent( "local:An application being tested" ) );
+
+		// Remove the application.
+		manager.removeApplication( app1 );
+
+		// Update the app which has just been removed, so nothing should happen.
+		app1.setDescription( "CHANGED!" );
+		manager.updateApplication( app1 );
+
+		// Wait for a while... just in case an (unwanted) update occurs.
+		Thread.sleep( 2 * POLL_INTERVAL );
+
+		// Generated reports should not have changed!
+		assertThat( global ).satisfies( hasContent( "global:An application being tested" ) );
+		assertThat( local ).satisfies( hasContent( "local:An application being tested" ) );
+
+		// Add additional templates.
+		addStringTemplate( manager, null, "global2.test", "global2:{{description}}" );
+		addStringTemplate( manager, app1, "local2.test", "local2:{{description}}" );
+
+		// Wait for a while... just in case an (unwanted) monitoring report generation occurs.
+		Thread.sleep( 2 * POLL_INTERVAL );
+
+		// Update the application, the reports should be updated synchronously.
+		manager.updateApplication( app1 );
+		assertThat( new File( targetDir, "test-app-1.global2.test" ) ).doesNotExist();
+		assertThat( new File( targetDir, "test-app-1" + File.separatorChar + "local2.test" ) ).doesNotExist();
+	}
+
+}

--- a/core/roboconf-dm-monitoring/src/test/java/net/roboconf/dm/monitoring/internal/MonitoringManagerTest.java
+++ b/core/roboconf-dm-monitoring/src/test/java/net/roboconf/dm/monitoring/internal/MonitoringManagerTest.java
@@ -36,8 +36,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static net.roboconf.dm.monitoring.MonitoringService.MONITORING_TARGET_DIRECTORY;
-import static net.roboconf.dm.monitoring.MonitoringService.MONITORING_TEMPLATE_DIRECTORY;
+import static net.roboconf.dm.monitoring.MonitoringService.TARGET_DIRECTORY;
+import static net.roboconf.dm.monitoring.MonitoringService.TEMPLATE_DIRECTORY;
 import static net.roboconf.dm.monitoring.internal.MonitoringTestUtils.addStringTemplate;
 import static net.roboconf.dm.monitoring.internal.MonitoringTestUtils.hasContent;
 import static org.fest.assertions.Assertions.assertThat;
@@ -79,43 +79,43 @@ public class MonitoringManagerTest {
 	 * A sample application.
 	 */
 	private final Application app1 = new Application()
-			.name( "test-app-1" )
-			.description( "An application being tested" )
-			.qualifier( "test" )
-			.graphs( new Graphs() );
+			.name("test-app-1")
+			.description("An application being tested")
+			.qualifier("test")
+			.graphs(new Graphs());
 
 	/**
 	 * Another sample application.
 	 */
 	private final Application app2 = new Application()
-			.name( "test-app-2" )
-			.description( "Another application being tested" )
-			.qualifier( "test" )
-			.graphs( new Graphs() );
+			.name("test-app-2")
+			.description("Another application being tested")
+			.qualifier("test")
+			.graphs(new Graphs());
 
 	@Before
 	public void before() throws IOException {
 		// Create the configuration directory.
 		final File configDir = tmpDir.newFolder();
-		templateDir = new File( configDir, MONITORING_TEMPLATE_DIRECTORY );
-		targetDir = new File( configDir, MONITORING_TARGET_DIRECTORY );
+		templateDir = new File(configDir, TEMPLATE_DIRECTORY);
+		targetDir = new File(configDir, TARGET_DIRECTORY);
 
 		// Create & configure the monitoring manager component.
 		manager = new MonitoringManager();
-		manager.setPollInterval( POLL_INTERVAL );
+		manager.setPollInterval(POLL_INTERVAL);
 		manager.start();
-		manager.startMonitoring( configDir );
+		manager.startMonitoring(configDir);
 
 		// Add the applications
-		manager.addApplication( app1 );
-		manager.addApplication( app2 );
+		manager.addApplication(app1);
+		manager.addApplication(app2);
 	}
 
 	@After
 	public void after() throws IOException {
 		// Remove the applications
-		manager.removeApplication( app1 );
-		manager.removeApplication( app2 );
+		manager.removeApplication(app1);
+		manager.removeApplication(app2);
 
 		manager.stopMonitoring();
 		manager.stop();
@@ -123,125 +123,125 @@ public class MonitoringManagerTest {
 
 	@Test
 	public void testRootDirectoriesAreCreated() {
-		assertThat( templateDir ).exists().isDirectory();
-		assertThat( targetDir ).exists().isDirectory();
+		assertThat(templateDir).exists().isDirectory();
+		assertThat(targetDir).exists().isDirectory();
 	}
 
 	@Test
 	public void testGlobalAndSpecificTemplates() throws IOException, InterruptedException {
 		// Add global & local (app-specific) templates.
-		addStringTemplate( manager, null, "global.test", "global:{{name}}" );
-		addStringTemplate( manager, app1, "local1.test", "app1:{{name}}" );
-		addStringTemplate( manager, app2, "local2.test", "app2:{{name}}" );
+		addStringTemplate(manager, null, "global.test", "global:{{name}}");
+		addStringTemplate(manager, app1, "local1.test", "app1:{{name}}");
+		addStringTemplate(manager, app2, "local2.test", "app2:{{name}}");
 
 		// Check the templates are here.
-		assertThat( manager.listTemplates( null ) ).containsOnly( "global.test" );
-		assertThat( manager.listTemplates( app1 ) ).containsOnly( "local1.test" );
-		assertThat( manager.listTemplates( app2 ) ).containsOnly( "local2.test" );
+		assertThat(manager.listTemplates(null)).containsOnly("global.test");
+		assertThat(manager.listTemplates(app1)).containsOnly("local1.test");
+		assertThat(manager.listTemplates(app2)).containsOnly("local2.test");
 
 		// Wait for a while, so the reports are generated.
-		Thread.sleep( 2 * POLL_INTERVAL );
+		Thread.sleep(2 * POLL_INTERVAL);
 
 		// Check the presence and the content of the global monitoring reports.
-		assertThat( new File( targetDir, "test-app-1.global.test" ) )
+		assertThat(new File(targetDir, "test-app-1.global.test"))
 				.exists()
 				.isFile()
-				.satisfies( hasContent( "global:test-app-1" ) );
-		assertThat( new File( targetDir, "test-app-2.global.test" ) )
+				.satisfies(hasContent("global:test-app-1"));
+		assertThat(new File(targetDir, "test-app-2.global.test"))
 				.exists()
 				.isFile()
-				.satisfies( hasContent( "global:test-app-2" ) );
+				.satisfies(hasContent("global:test-app-2"));
 
 		// Check the presence and the content of the local monitoring reports.
-		assertThat( new File( targetDir, "test-app-1" + File.separatorChar + "local1.test" ) )
+		assertThat(new File(targetDir, "test-app-1" + File.separatorChar + "local1.test"))
 				.exists()
 				.isFile()
-				.satisfies( hasContent( "app1:test-app-1" ) );
-		assertThat( new File( targetDir, "test-app-2" + File.separatorChar + "local2.test" ) )
+				.satisfies(hasContent("app1:test-app-1"));
+		assertThat(new File(targetDir, "test-app-2" + File.separatorChar + "local2.test"))
 				.exists()
 				.isFile()
-				.satisfies( hasContent( "app2:test-app-2" ) );
+				.satisfies(hasContent("app2:test-app-2"));
 
 		// Remove the applications
-		manager.removeApplication( app1 );
-		manager.removeApplication( app2 );
+		manager.removeApplication(app1);
+		manager.removeApplication(app2);
 	}
 
 	@Test
 	public void testUpdateApplication() throws IOException, InterruptedException {
 		// Add global & local (app-specific) templates.
-		addStringTemplate( manager, null, "global.test", "global:{{description}}" );
-		addStringTemplate( manager, app1, "local1.test", "app1:{{description}}" );
+		addStringTemplate(manager, null, "global.test", "global:{{description}}");
+		addStringTemplate(manager, app1, "local1.test", "app1:{{description}}");
 
-		final File global = new File( targetDir, "test-app-1.global.test" );
-		final File local = new File( targetDir, "test-app-1" + File.separatorChar + "local1.test" );
+		final File global = new File(targetDir, "test-app-1.global.test");
+		final File local = new File(targetDir, "test-app-1" + File.separatorChar + "local1.test");
 
 		// Wait for a while, so the reports are generated.
-		Thread.sleep( 2 * POLL_INTERVAL );
+		Thread.sleep(2 * POLL_INTERVAL);
 
 		// Check the presence and the content of the global monitoring reports.
-		assertThat( global ).exists().isFile().satisfies( hasContent( "global:An application being tested" ) );
+		assertThat(global).exists().isFile().satisfies(hasContent("global:An application being tested"));
 
 		// Check the presence and the content of the local monitoring reports.
-		assertThat( local ).exists().isFile().satisfies( hasContent( "app1:An application being tested" ) );
+		assertThat(local).exists().isFile().satisfies(hasContent("app1:An application being tested"));
 
 		// Change the application, check, update, and recheck!
-		app1.setDescription( "CHANGED!" );
+		app1.setDescription("CHANGED!");
 
 		// Wait for a while... just in case an (unwanted) update occurs.
-		Thread.sleep( 2 * POLL_INTERVAL );
+		Thread.sleep(2 * POLL_INTERVAL);
 
 		// Should not have changed!
-		assertThat( global ).satisfies( hasContent( "global:An application being tested" ) );
-		assertThat( local ).satisfies( hasContent( "app1:An application being tested" ) );
+		assertThat(global).satisfies(hasContent("global:An application being tested"));
+		assertThat(local).satisfies(hasContent("app1:An application being tested"));
 
 		// Update the application, the reports should be updated synchronously.
-		manager.updateApplication( app1 );
-		assertThat( global ).satisfies( hasContent( "global:CHANGED!" ) );
-		assertThat( local ).satisfies( hasContent( "app1:CHANGED!" ) );
+		manager.updateApplication(app1);
+		assertThat(global).satisfies(hasContent("global:CHANGED!"));
+		assertThat(local).satisfies(hasContent("app1:CHANGED!"));
 	}
 
 	@Test
 	public void testRemoveApplication() throws IOException, InterruptedException {
 		// Add global & local (app-specific) templates.
-		addStringTemplate( manager, null, "global.test", "global:{{description}}" );
-		addStringTemplate( manager, app1, "local.test", "local:{{description}}" );
+		addStringTemplate(manager, null, "global.test", "global:{{description}}");
+		addStringTemplate(manager, app1, "local.test", "local:{{description}}");
 
-		final File global = new File( targetDir, "test-app-1.global.test" );
-		final File local = new File( targetDir, "test-app-1" + File.separatorChar + "local.test" );
+		final File global = new File(targetDir, "test-app-1.global.test");
+		final File local = new File(targetDir, "test-app-1" + File.separatorChar + "local.test");
 
 		// Wait for a while, so the reports are generated.
-		Thread.sleep( 2 * POLL_INTERVAL );
+		Thread.sleep(2 * POLL_INTERVAL);
 
 		// Check the presence and the content monitoring reports.
-		assertThat( global ).exists().isFile().satisfies( hasContent( "global:An application being tested" ) );
-		assertThat( local ).exists().isFile().satisfies( hasContent( "local:An application being tested" ) );
+		assertThat(global).exists().isFile().satisfies(hasContent("global:An application being tested"));
+		assertThat(local).exists().isFile().satisfies(hasContent("local:An application being tested"));
 
 		// Remove the application.
-		manager.removeApplication( app1 );
+		manager.removeApplication(app1);
 
 		// Update the app which has just been removed, so nothing should happen.
-		app1.setDescription( "CHANGED!" );
-		manager.updateApplication( app1 );
+		app1.setDescription("CHANGED!");
+		manager.updateApplication(app1);
 
 		// Wait for a while... just in case an (unwanted) update occurs.
-		Thread.sleep( 2 * POLL_INTERVAL );
+		Thread.sleep(2 * POLL_INTERVAL);
 
 		// Generated reports should not have changed!
-		assertThat( global ).satisfies( hasContent( "global:An application being tested" ) );
-		assertThat( local ).satisfies( hasContent( "local:An application being tested" ) );
+		assertThat(global).satisfies(hasContent("global:An application being tested"));
+		assertThat(local).satisfies(hasContent("local:An application being tested"));
 
 		// Add additional templates.
-		addStringTemplate( manager, null, "global2.test", "global2:{{description}}" );
-		addStringTemplate( manager, app1, "local2.test", "local2:{{description}}" );
+		addStringTemplate(manager, null, "global2.test", "global2:{{description}}");
+		addStringTemplate(manager, app1, "local2.test", "local2:{{description}}");
 
 		// Wait for a while... just in case an (unwanted) monitoring report generation occurs.
-		Thread.sleep( 2 * POLL_INTERVAL );
+		Thread.sleep(2 * POLL_INTERVAL);
 
 		// Update the application, the reports should be updated synchronously.
-		manager.updateApplication( app1 );
-		assertThat( new File( targetDir, "test-app-1.global2.test" ) ).doesNotExist();
-		assertThat( new File( targetDir, "test-app-1" + File.separatorChar + "local2.test" ) ).doesNotExist();
+		manager.updateApplication(app1);
+		assertThat(new File(targetDir, "test-app-1.global2.test")).doesNotExist();
+		assertThat(new File(targetDir, "test-app-1" + File.separatorChar + "local2.test")).doesNotExist();
 	}
 
 }

--- a/core/roboconf-dm-monitoring/src/test/java/net/roboconf/dm/monitoring/internal/MonitoringTestUtils.java
+++ b/core/roboconf-dm-monitoring/src/test/java/net/roboconf/dm/monitoring/internal/MonitoringTestUtils.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.monitoring.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.Template;
+import net.roboconf.core.model.beans.Application;
+import net.roboconf.core.utils.Utils;
+import org.fest.assertions.Condition;
+
+/**
+ * Utility methods dedicated to the testing of the Roboconf monitoring support.
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public class MonitoringTestUtils {
+
+	// Prevent instantiations.
+	private MonitoringTestUtils() {
+	}
+
+	/**
+	 * Create a condition that matches {@code File}s with a content equal to the given value.
+	 *
+	 * @param expectedContent the expected content of the file.
+	 * @return the created matcher.
+	 */
+	public static Condition<File> hasContent( final String expectedContent ) {
+		return new Condition<File>( "file has content \"" + expectedContent + "\"" ) {
+			@Override
+			public boolean matches( File value ) {
+				String actualContent;
+				try {
+					actualContent = Utils.readFileContent( value );
+				} catch (final IOException e) {
+					// Hum... Embarrassing!
+					actualContent = null;
+				}
+				return Objects.equals( expectedContent, actualContent );
+			}
+		};
+	}
+
+	/**
+	 * Add a template to the monitoring manager.
+	 * <p>
+	 * The template string content string is converted to an {@code InputStream} before being passed to the
+	 * {@link net.roboconf.dm.monitoring.MonitoringService#addTemplate(Application, String, InputStream)} method.
+	 * </p>
+	 * @param monitoringManager the Roboconf monitoring manager being tested.
+	 * @param application the application scope for the template to add, or {@code null} to add a global template.
+	 * @param name        the name of the template to add.
+	 * @param content     the string content of the template to add.
+	 * @return {@code true} is the template was successfully added, {@code false} if there is already a template with
+	 * the same name.
+	 * 
+	 * @throws IOException if the template cannot be added because of an IO error.
+	 */
+	public static boolean addStringTemplate( final MonitoringManager monitoringManager,
+								   final Application application,
+								   final String name,
+								   final String content ) throws IOException {
+		return monitoringManager.addTemplate(application, name, new ByteArrayInputStream( content.getBytes() ) );
+	}
+
+	/**
+	 * Map the given instances by their path.
+	 *
+	 * @param instances the instances to map.
+	 * @return the map of the given instances, indexed by path.
+	 */
+	public static Map<String, InstanceContextBean> instancesByPath( final Collection<InstanceContextBean> instances ) {
+		final Map<String, InstanceContextBean> result = new LinkedHashMap<String, InstanceContextBean>();
+		for (final InstanceContextBean instance : instances) {
+			result.put( instance.getPath(), instance );
+		}
+		return result;
+	}
+
+	/**
+	 * Transform the given set of variable contexts to a {@code string -> string} map.
+	 * <p>The result of this method is left unspecified if the given set contains the same variable definition more
+	 * than once.</p>
+	 *
+	 * @param variables the variables to map.
+	 * @return the map with, for each provided variable, its name as key and its value as value.
+	 */
+	public static Map<String, String> variableMapOf( final Set<VariableContextBean> variables ) {
+		final Map<String, String> result = new LinkedHashMap<String, String>();
+		for (final VariableContextBean var : variables) {
+			result.put( var.getName(), var.getValue() );
+		}
+		return result;
+	}
+
+	/**
+	 * Process the given template, using the given monitoring context.
+	 * <p>
+	 * This method relies on the {@code MonitoringManager} and friends classes to process the template. So the result is
+	 * exactly the same as the one that would be written in a monitoring report by the manager. 
+	 * </p>
+	 * 
+	 * @param template the template to apply.
+	 * @param context the monitoring context of an application.   
+	 * @return the result of the template application to the given context.
+	 */
+	public static String processTemplate(final Template template, final ApplicationContextBean context) {
+		// TODO
+		return null;
+	}
+
+}

--- a/core/roboconf-dm-monitoring/src/test/java/net/roboconf/dm/monitoring/internal/MonitoringTestUtils.java
+++ b/core/roboconf-dm-monitoring/src/test/java/net/roboconf/dm/monitoring/internal/MonitoringTestUtils.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Template;
 import net.roboconf.core.model.beans.Application;
 import net.roboconf.core.utils.Utils;
@@ -59,17 +58,17 @@ public class MonitoringTestUtils {
 	 * @return the created matcher.
 	 */
 	public static Condition<File> hasContent( final String expectedContent ) {
-		return new Condition<File>( "file has content \"" + expectedContent + "\"" ) {
+		return new Condition<File>("file has content \"" + expectedContent + "\"") {
 			@Override
 			public boolean matches( File value ) {
 				String actualContent;
 				try {
-					actualContent = Utils.readFileContent( value );
+					actualContent = Utils.readFileContent(value);
 				} catch (final IOException e) {
 					// Hum... Embarrassing!
 					actualContent = null;
 				}
-				return Objects.equals( expectedContent, actualContent );
+				return Objects.equals(expectedContent, actualContent);
 			}
 		};
 	}
@@ -80,20 +79,21 @@ public class MonitoringTestUtils {
 	 * The template string content string is converted to an {@code InputStream} before being passed to the
 	 * {@link net.roboconf.dm.monitoring.MonitoringService#addTemplate(Application, String, InputStream)} method.
 	 * </p>
+	 *
 	 * @param monitoringManager the Roboconf monitoring manager being tested.
-	 * @param application the application scope for the template to add, or {@code null} to add a global template.
-	 * @param name        the name of the template to add.
-	 * @param content     the string content of the template to add.
+	 * @param application       the application scope for the template to add, or {@code null} to add a global
+	 *                          template.
+	 * @param name              the name of the template to add.
+	 * @param content           the string content of the template to add.
 	 * @return {@code true} is the template was successfully added, {@code false} if there is already a template with
 	 * the same name.
-	 * 
 	 * @throws IOException if the template cannot be added because of an IO error.
 	 */
 	public static boolean addStringTemplate( final MonitoringManager monitoringManager,
-								   final Application application,
-								   final String name,
-								   final String content ) throws IOException {
-		return monitoringManager.addTemplate(application, name, new ByteArrayInputStream( content.getBytes() ) );
+											 final Application application,
+											 final String name,
+											 final String content ) throws IOException {
+		return monitoringManager.addTemplate(application, name, new ByteArrayInputStream(content.getBytes()));
 	}
 
 	/**
@@ -105,15 +105,17 @@ public class MonitoringTestUtils {
 	public static Map<String, InstanceContextBean> instancesByPath( final Collection<InstanceContextBean> instances ) {
 		final Map<String, InstanceContextBean> result = new LinkedHashMap<String, InstanceContextBean>();
 		for (final InstanceContextBean instance : instances) {
-			result.put( instance.getPath(), instance );
+			result.put(instance.getPath(), instance);
 		}
 		return result;
 	}
 
 	/**
 	 * Transform the given set of variable contexts to a {@code string -> string} map.
-	 * <p>The result of this method is left unspecified if the given set contains the same variable definition more
-	 * than once.</p>
+	 * <p>
+	 * The result of this method is left unspecified if the given set contains the same variable definition more than
+	 * once.
+	 * </p>
 	 *
 	 * @param variables the variables to map.
 	 * @return the map with, for each provided variable, its name as key and its value as value.
@@ -121,7 +123,7 @@ public class MonitoringTestUtils {
 	public static Map<String, String> variableMapOf( final Set<VariableContextBean> variables ) {
 		final Map<String, String> result = new LinkedHashMap<String, String>();
 		for (final VariableContextBean var : variables) {
-			result.put( var.getName(), var.getValue() );
+			result.put(var.getName(), var.getValue());
 		}
 		return result;
 	}
@@ -129,15 +131,15 @@ public class MonitoringTestUtils {
 	/**
 	 * Process the given template, using the given monitoring context.
 	 * <p>
-	 * This method relies on the {@code MonitoringManager} and friends classes to process the template. So the result is
-	 * exactly the same as the one that would be written in a monitoring report by the manager. 
+	 * This method relies on the {@code MonitoringManager} and friends classes to process the template. So the result
+	 * is exactly the same as the one that would be written in a monitoring report by the manager.
 	 * </p>
-	 * 
+	 *
 	 * @param template the template to apply.
-	 * @param context the monitoring context of an application.   
+	 * @param context  the monitoring context of an application.
 	 * @return the result of the template application to the given context.
 	 */
-	public static String processTemplate(final Template template, final ApplicationContextBean context) {
+	public static String processTemplate( final Template template, final ApplicationContextBean context ) {
 		// TODO
 		return null;
 	}

--- a/core/roboconf-dm-monitoring/src/test/resources/example-app/descriptor/application.properties
+++ b/core/roboconf-dm-monitoring/src/test/resources/example-app/descriptor/application.properties
@@ -1,0 +1,7 @@
+application-name = example-app
+application-qualifier = sample
+application-namespace = net.roboconf
+application-dsl-id = roboconf-1.0
+application-description = An example application
+graph-entry-point = example.graph
+instance-entry-point = example.instances

--- a/core/roboconf-dm-monitoring/src/test/resources/example-app/graph/example.graph
+++ b/core/roboconf-dm-monitoring/src/test/resources/example-app/graph/example.graph
@@ -1,0 +1,51 @@
+# The facets.
+facet Virtual {
+}
+
+facet Machine {
+}
+
+facet Service {
+}
+
+facet Application {
+}
+
+facet VirtualMachine {
+	extends: Virtual, Machine;
+}
+
+facet NetworkService {
+	extends: Service;
+}
+
+# The components
+Vm {
+	facets: VirtualMachine;
+	installer: target;
+}
+
+MySql {
+	facets: NetworkService;
+	installer: puppet;
+	exports: ip, port = 3306;
+}
+
+Apache {
+	facets: NetworkService;
+	installer: script;
+	imports: Tomcat.ip, Tomcat.ajpPort;
+}
+
+Tomcat {
+	facets: NetworkService;
+	installer: docker;
+	exports: ip, ajpPort = 8009;
+	imports: MySql.ip, MySql.port;
+}
+
+War {
+	facets: Application;
+	installer: human;
+	imports: MySql.*;
+}

--- a/core/roboconf-dm-monitoring/src/test/resources/example-app/instances/example.instances
+++ b/core/roboconf-dm-monitoring/src/test/resources/example-app/instances/example.instances
@@ -1,0 +1,25 @@
+instance of Vm {
+	name: ApacheVm;
+	instance of Apache {
+		name: Apache;
+	}
+}
+
+instance of Vm {
+	name: MySqlVm;
+	instance of MySql {
+		name: MySql;
+	}
+}
+
+instance of Vm {
+	name: TomcatVm;
+	count: 2;
+	instance of Tomcat {
+		name: Tomcat;
+		ajpPort: 9021;
+		instance of War {
+			name: WebApp;
+		}
+	}
+}

--- a/core/roboconf-dm/metadata.xml
+++ b/core/roboconf-dm/metadata.xml
@@ -11,6 +11,10 @@
 			<callback type="unbind" method="targetDisappears" />
 			<callback type="modified" method="targetWasModified" />
 		</requires>
+		<requires optional="true">
+			<callback type="bind" method="bindMonitoringManager" />
+			<callback type="unbind" method="unbindMonitoringManager" />
+		</requires>
 		
 		<callback transition="validate" method="start" />
 		<callback transition="invalidate" method="stop" />

--- a/core/roboconf-dm/src/main/java/net/roboconf/dm/management/MonitoringManagerService.java
+++ b/core/roboconf-dm/src/main/java/net/roboconf/dm/management/MonitoringManagerService.java
@@ -38,14 +38,14 @@ import net.roboconf.core.model.beans.Application;
 public interface MonitoringManagerService {
 
 	/**
-	 * Start the monitoring, using the provided Roboconf configuration directory.
+	 * Starts the monitoring, using the provided Roboconf configuration directory.
 	 *
 	 * @param configDir the Roboconf configuration directory.
 	 */
 	void startMonitoring( File configDir );
 
 	/**
-	 * Add the given application to the monitoring manager, so it can start to monitor it.<p>This method is called by
+	 * Adds the given application to the monitoring manager, so it can start to monitor it.<p>This method is called by
 	 * the Roboconf DM when an application is added, or when binding to the monitoring manager.</p>
 	 *
 	 * @param app the application to add.
@@ -54,7 +54,7 @@ public interface MonitoringManagerService {
 	void addApplication( Application app );
 
 	/**
-	 * Notify the monitoring manager that the given application model has changed, and that the monitoring reports must
+	 * Notifies the monitoring manager that the given application model has changed, and that the monitoring reports must
 	 * be regenerated.
 	 *
 	 * @param app the changing application.
@@ -63,8 +63,8 @@ public interface MonitoringManagerService {
 	void updateApplication( Application app );
 
 	/**
-	 * Remove the given application from the monitoring manager, so it stops to be monitored.<p>This method is called by
-	 * the Roboconf DM when an application is removed.</p><p>The monitoring templates and reports sepcific to the
+	 * Removes the given application from the monitoring manager, so it stops to be monitored.<p>This method is called
+	 * by the Roboconf DM when an application is removed.</p><p>The monitoring templates and reports specific to the
 	 * application being removed are <em>kept and left untouched.</em></p>
 	 *
 	 * @param app the application to remove.
@@ -73,7 +73,7 @@ public interface MonitoringManagerService {
 	void removeApplication( Application app );
 
 	/**
-	 * Stop the monitoring. All the applications that are currently monitored are removed, and must be re-added after
+	 * Stops the monitoring. All the applications that are currently monitored are removed, and must be re-added after
 	 * this service has been {@linkplain #startMonitoring(File) started} again.
 	 */
 	void stopMonitoring();

--- a/core/roboconf-dm/src/main/java/net/roboconf/dm/management/MonitoringManagerService.java
+++ b/core/roboconf-dm/src/main/java/net/roboconf/dm/management/MonitoringManagerService.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2013-2015 Linagora, Université Joseph Fourier, Floralis
+ *
+ * The present code is developed in the scope of the joint LINAGORA -
+ * Université Joseph Fourier - Floralis research program and is designated
+ * as a "Result" pursuant to the terms and conditions of the LINAGORA
+ * - Université Joseph Fourier - Floralis research program. Each copyright
+ * holder of Results enumerated here above fully & independently holds complete
+ * ownership of the complete Intellectual Property rights applicable to the whole
+ * of said Results, and may freely exploit it in any manner which does not infringe
+ * the moral rights of the other copyright holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.roboconf.dm.management;
+
+import java.io.File;
+
+import net.roboconf.core.model.beans.Application;
+
+/**
+ * Interface for Roboconf application's monitoring support.<p>This interface is <em>not</em> intended to be used by
+ * consumers. They should use the {@code net.roboconf.dm.monitoring.MonitoringService} interface instead.</p>
+ *
+ * @author Pierre Bourret - Université Joseph Fourier
+ */
+public interface MonitoringManagerService {
+
+	/**
+	 * Start the monitoring, using the provided Roboconf configuration directory.
+	 *
+	 * @param configDir the Roboconf configuration directory.
+	 */
+	void startMonitoring( File configDir );
+
+	/**
+	 * Add the given application to the monitoring manager, so it can start to monitor it.<p>This method is called by
+	 * the Roboconf DM when an application is added, or when binding to the monitoring manager.</p>
+	 *
+	 * @param app the application to add.
+	 * @throws IllegalStateException if monitoring is currently stopped.
+	 */
+	void addApplication( Application app );
+
+	/**
+	 * Notify the monitoring manager that the given application model has changed, and that the monitoring reports must
+	 * be regenerated.
+	 *
+	 * @param app the changing application.
+	 * @throws IllegalStateException if monitoring is currently stopped.
+	 */
+	void updateApplication( Application app );
+
+	/**
+	 * Remove the given application from the monitoring manager, so it stops to be monitored.<p>This method is called by
+	 * the Roboconf DM when an application is removed.</p><p>The monitoring templates and reports sepcific to the
+	 * application being removed are <em>kept and left untouched.</em></p>
+	 *
+	 * @param app the application to remove.
+	 * @throws IllegalStateException if monitoring is currently stopped.
+	 */
+	void removeApplication( Application app );
+
+	/**
+	 * Stop the monitoring. All the applications that are currently monitored are removed, and must be re-added after
+	 * this service has been {@linkplain #startMonitoring(File) started} again.
+	 */
+	void stopMonitoring();
+
+}

--- a/karaf/roboconf-karaf-feature-dm/src/main/feature/feature.xml
+++ b/karaf/roboconf-karaf-feature-dm/src/main/feature/feature.xml
@@ -21,6 +21,7 @@
 		<bundle>mvn:net.roboconf/roboconf-dm/${project.version}</bundle>
 		<bundle>mvn:net.roboconf/roboconf-dm-web-administration/${project.version}/war</bundle>
 		<bundle>mvn:net.roboconf/roboconf-target-api/${project.version}</bundle>
+		<bundle>mvn:net.roboconf/roboconf-dm-monitoring/${project.version}</bundle>
 		
 		<!-- Optional bundles, to start depending on our needs -->
 		<!-- Deployment targets handlers could go here. -->

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
 		<module>core/roboconf-agent-monitoring</module>
 		
 		<module>core/roboconf-dm</module>
+		<module>core/roboconf-dm-monitoring</module>
 		<module>core/roboconf-dm-rest-commons</module>
 		<module>core/roboconf-dm-rest-services</module>
 		


### PR DESCRIPTION
Resolve #155 (Add Monitoring Support)

Monitoring templates can be dropped in the Roboconf configuration directory:
- either in the monitoring-template directory, in this case the template is global to all applications.
- or in the {applicationName}/monitoring-template directory, in this case the template is specific to that application.

The templates use a {{mustache}} based syntax, extended with Handlebars features + Roboconf specific operators (helpers).
See the Roboconf Specification Request 232 (Monitoring Template Language) for a complete description of the template syntax.
The monitoring reports output syntax can be virtually anything (text-based).

The monitoring manager scans the Roboconf configuration directory for changes in the templates. If a template is added/modified,
the corresponding monitoring reports is generated/updated. Reports are *not* removed whan a template has gone.

The monitoring part is *optional*: it means the Roboconf DM can work perfectly without the presence of the monitoring manager bundle.